### PR TITLE
Bump version to 1.1.7 and update dependencies

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "OptimalControl"
 uuid = "5f98b655-cc9a-415a-b60e-744165666948"
 authors = ["Olivier Cots <olivier.cots@toulouse-inp.fr>"]
-version = "1.1.6"
+version = "1.1.7"
 
 [deps]
 ADNLPModels = "54578032-b7ea-4c30-94aa-7cbd1cce6c9a"
@@ -17,11 +17,11 @@ RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
 
 [compat]
 ADNLPModels = "0.8"
-CTBase = "0.16"
+CTBase = "0.17"
 CTDirect = "0.17"
 CTFlows = "0.8"
 CTModels = "0.6"
-CTParser = "0.7"
+CTParser = "0.8"
 CommonSolve = "0.2"
 DocStringExtensions = "0.9"
 ExaModels = "0.9"


### PR DESCRIPTION
@ocots
- Updated version and compatibility for dependencies
- some (minor) bug fixes in CTParser, got to propagate
- also needs CTBase v0.17 because of CTParser dep.; any issue with that...

EDIT: ... apart from the fact that we need to propagate CTBase bump everywhere 😬. waiting your 🚦
- plus CTModels that has CTBase 0.17 and breaks (need for CTSolver, and so CTDirect update @PierreMartinon) 