### PR TITLE
Release v2.0.1

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -2,6 +2,9 @@
 
 This document describes the breaking changes when migrating from **OptimalControl.jl v1.1.6** (last stable release) to **v2.0.0**.
 
+!!! note "v2.0.1 Compatibility"
+    **v2.0.1** is fully backward compatible with v2.0.0. It contains documentation improvements and an export change (`build_initial_guess` is now explicitly reexported) with no breaking changes.
+
 ## Overview
 
 Version 2.0.0 represents a major architectural redesign of OptimalControl.jl, introducing:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [2.0.1] — 2026-04-13
+
+### Changed
+
+- **Exports**:
+  - `build_initial_guess` is now explicitly reexported with `@reexport import` for better visibility
+
+- **Documentation improvements**:
+  - Added anchor link to "Strategy options" section in manual-solve.md for better navigation
+  - Updated `route_to` documentation to support multi-strategy routing with positional syntax
+  - Changed `route_to` syntax examples from keyword arguments (`route_to(exa=12)`) to positional arguments (`route_to(:exa, 12)`)
+  - Added documentation for routing the same option to multiple strategies with different values using alternating strategy-value pairs
+
+---
+
 ## [2.0.0] — 2026-04-03
 
 **Major version release** with complete solve architecture redesign. This release introduces breaking changes from v1.1.6 (last stable release). See [BREAKING.md](BREAKING.md) for detailed migration guide.

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "OptimalControl"
 uuid = "5f98b655-cc9a-415a-b60e-744165666948"
-version = "2.0.0"
+version = "2.0.1"
 authors = ["Olivier Cots <olivier.cots@toulouse-inp.fr>"]
 
 [deps]

--- a/src/imports/ctmodels.jl
+++ b/src/imports/ctmodels.jl
@@ -10,7 +10,8 @@ using CTModels: CTModels
 @reexport import RecipesBase: plot, plot!
 
 # Initial guess
-import CTModels: AbstractInitialGuess, InitialGuess, build_initial_guess
+import CTModels: AbstractInitialGuess, InitialGuess
+@reexport import CTModels: build_initial_guess
 
 # Serialization
 @reexport import CTModels: export_ocp_solution, import_ocp_solution

--- a/test/suite/reexport/test_ctmodels.jl
+++ b/test/suite/reexport/test_ctmodels.jl
@@ -46,7 +46,7 @@ function test_ctmodels()
             for f in (:build_initial_guess,)
                 Test.@testset "$f" begin
                     Test.@test isdefined(OptimalControl, f)
-                    Test.@test !isdefined(CurrentModule, f)
+                    Test.@test isdefined(CurrentModule, f)
                     Test.@test getfield(OptimalControl, f) isa Function
                 end
             end


### PR DESCRIPTION
- Reexport build_initial_guess explicitly for better visibility
- Documentation improvements:
  - Add anchor link to Strategy options section
  - Update route_to documentation with multi-strategy routing
  - Change route_to syntax from keyword to positional arguments
- Update tests to verify build_initial_guess export
- Bump version to 2.0.1