### PR TITLE
ci: stop label-gated workflows from re-triggering on every subsequent label

### DIFF
--- a/.github/workflows/Breakage.yml
+++ b/.github/workflows/Breakage.yml
@@ -9,7 +9,14 @@ on:
 
 jobs:
   break-pkg:
-    if: contains(github.event.pull_request.labels.*.name, 'run breakage')
+    # A 'labeled' event fires once per label added, and re-evaluates against the PR's
+    # *current* full label set — so adding several labels in a row would otherwise
+    # re-run this job on every subsequent label add. Only react to 'labeled' when it's
+    # this specific label; for other trigger types (opened/synchronize/reopened), fall
+    # back to checking the current label set as before.
+    if: >
+      (github.event.action == 'labeled' && github.event.label.name == 'run breakage') ||
+      (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'run breakage'))
     strategy:
       fail-fast: false
       matrix:
@@ -34,7 +41,10 @@ jobs:
     secrets:
       SSH_KEY: ${{ secrets.SSH_KEY }}
   break-pkg-app:
-    if: contains(github.event.pull_request.labels.*.name, 'run breakage applications')
+    # See the comment on break-pkg above.
+    if: >
+      (github.event.action == 'labeled' && github.event.label.name == 'run breakage applications') ||
+      (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'run breakage applications'))
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -10,7 +10,15 @@ on:
     
 jobs:
   test-cpu-github:
-    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'run ci cpu')
+    # A 'labeled' event fires once per label added, and re-evaluates against the PR's
+    # *current* full label set — so adding several labels in a row would otherwise
+    # re-run this job on every subsequent label add. Only react to 'labeled' when it's
+    # this specific label; for other trigger types (opened/synchronize/reopened), fall
+    # back to checking the current label set as before.
+    if: >
+      github.event_name != 'pull_request' ||
+      (github.event.action == 'labeled' && github.event.label.name == 'run ci cpu') ||
+      (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'run ci cpu'))
     uses: control-toolbox/CTActions/.github/workflows/ci.yml@main
     with:
       versions: '["1.12"]'
@@ -22,7 +30,11 @@ jobs:
 
   # Job pour le runner self-hosted kkt (GPU/CUDA)
   test-gpu-kkt:
-    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'run ci gpu')
+    # See the comment on test-cpu-github above.
+    if: >
+      github.event_name != 'pull_request' ||
+      (github.event.action == 'labeled' && github.event.label.name == 'run ci gpu') ||
+      (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'run ci gpu'))
     uses: control-toolbox/CTActions/.github/workflows/ci.yml@main
     with:
       versions: '["1"]'

--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -10,7 +10,15 @@ on:
   
 jobs:
   call:
-    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'run documentation')
+    # A 'labeled' event fires once per label added, and re-evaluates against the PR's
+    # *current* full label set — so adding several labels in a row would otherwise
+    # re-run this job on every subsequent label add. Only react to 'labeled' when it's
+    # this specific label; for other trigger types (opened/synchronize/reopened), fall
+    # back to checking the current label set as before.
+    if: >
+      github.event_name != 'pull_request' ||
+      (github.event.action == 'labeled' && github.event.label.name == 'run documentation') ||
+      (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'run documentation'))
     uses: control-toolbox/CTActions/.github/workflows/documentation.yml@main
     with:
       use_ct_registry: true


### PR DESCRIPTION
## Root cause

GitHub Actions fires a *separate* `pull_request` event of type `labeled` for **each label added individually**, and the `if:` condition on a gated job is re-evaluated against the PR's *current* full label set every time — not just the label that triggered this specific event.

So if a PR gets labels `run ci cpu`, then `run ci gpu`, then `run documentation` added one after another, the CPU-CI job (already matched by the first label) gets needlessly re-run again on the second and third label-add events too, since its label is still present in the full set. Same for any other job gated the same way. This wastes CI runs and clutters the Actions tab.

## Fix

For the `labeled` event specifically, check `github.event.label.name` against the job's own gating label (so only the newly-added label triggers it); for every other trigger type (`opened`/`synchronize`/`reopened`/push), fall back to the existing full-label-set check via `contains(github.event.pull_request.labels.*.name, '...')`, unchanged.

## Files touched

- `.github/workflows/CI.yml`
  - `test-cpu-github` — label `run ci cpu`
  - `test-gpu-kkt` — label `run ci gpu`
- `.github/workflows/Documentation.yml`
  - `call` — label `run documentation`
- `.github/workflows/Breakage.yml`
  - `break-pkg` — label `run breakage`
  - `break-pkg-app` — label `run breakage applications`

All other workflow files (`AddToProject.yml`, `AutoAssign.yml`, `CompatHelper.yml`, `Coverage.yml`, `Formatter.yml`, `SpellCheck.yml`, `TagBot.yml`, `UpdateReadme.yml`) were verified via `grep -rl "labeled" .github/workflows/` and do not use the `labeled` trigger / label-gating pattern, so they were left untouched.

Each job's own label name and every other part of its `if:` condition are preserved exactly as before — only the labeled-event-aware branching was added, matching the fix already applied in CTFlows.jl and CTBase.

## Validation

```
python3 -c "import yaml; [yaml.safe_load(open(f)) for f in ['.github/workflows/CI.yml', '.github/workflows/Breakage.yml', '.github/workflows/Documentation.yml']]; print('OK')"
```
→ `OK`

🤖 Generated with [Claude Code](https://claude.com/claude-code)