### PR TITLE
Reject unconsumed options in explicit solve mode

### DIFF
--- a/docs/src/manual-solve-explicit.md
+++ b/docs/src/manual-solve-explicit.md
@@ -182,13 +182,43 @@ nothing # hide
 
     If you have many undeclared options, you can use `mode=:permissive` to disable validation globally. However, this is not recommended as it will also ignore typos in valid option names.
 
+### Strategy options must be configured at construction
+
+In explicit mode, options specific to a strategy must be passed when constructing that strategy. They are not routed from the `solve` call.
+
+The following syntax is **invalid**:
+
+```julia
+disc = OptimalControl.Collocation()
+solve(ocp; disc, backend=:generic)
+```
+
+Because `disc` is a typed component, this call automatically selects explicit mode. `backend` is not an option of the `solve` action; it is an option of a modeler or solver strategy. The error does not mean that `backend` was lost or not transmitted. It means that an explicit component was combined with descriptive-style option syntax.
+
+Configure the modeler first, then pass the configured strategy to `solve`:
+
+```julia
+disc = OptimalControl.Collocation()
+modeler = OptimalControl.ADNLP(backend=:generic)
+result = solve(ocp; discretizer=disc, modeler=modeler)
+```
+
+If an option is declared by one of the completed strategies, the error identifies that strategy and suggests constructing it with the option. If the option is not declared by any strategy, the error reports an unknown option and lists the options accepted directly by `solve`, such as `initial_guess`, `init`, and `display`.
+
+`route_to` is only for descriptive mode. Likewise, `bypass` and `force` do not bypass explicit-mode validation. They can be used for undeclared options while constructing a strategy:
+
+```julia
+modeler = OptimalControl.ADNLP(custom_option=bypass(value))
+solve(ocp; modeler=modeler)
+```
+
 ### No routing needed
 
-In explicit mode, there's no option routing or ambiguity:
+In explicit mode, there is no automatic option routing:
 
-- Options go directly to the component you're configuring
-- No need for `route_to` (it's only for descriptive mode)
-- No automatic routing between strategies
+- Strategy options are passed to strategy constructors
+- `solve` accepts action options and typed component instances
+- `route_to` is only relevant to descriptive mode
 
 ```@example explicit
 # Each component gets its own options directly

--- a/src/OptimalControl.jl
+++ b/src/OptimalControl.jl
@@ -90,6 +90,7 @@ include(joinpath(@__DIR__, "helpers", "component_checks.jl"))
 include(joinpath(@__DIR__, "helpers", "strategy_builders.jl"))
 include(joinpath(@__DIR__, "helpers", "component_completion.jl"))
 include(joinpath(@__DIR__, "helpers", "descriptive_routing.jl"))
+include(joinpath(@__DIR__, "helpers", "explicit_validation.jl"))
 
 # solve
 include(joinpath(@__DIR__, "solve", "mode.jl"))

--- a/src/helpers/explicit_validation.jl
+++ b/src/helpers/explicit_validation.jl
@@ -3,20 +3,40 @@ $(TYPEDSIGNATURES)
 
 Return keyword arguments that are not explicit component instances or canonical
 component keywords.
+
+Reuses [`_descriptive_families`](@ref) as the single source of truth for component
+keyword names and abstract types, so this stays in sync with descriptive mode.
 """
 function _extract_explicit_component_kwargs(kwargs::Base.Pairs)
-    component_names = (:discretizer, :modeler, :solver)
+    families = _descriptive_families()
     remaining = NamedTuple(
         key => value for (key, value) in kwargs if
-        key ∉ component_names && !_is_explicit_component(value)
+        key ∉ keys(families) && !_is_explicit_component(value, families)
     )
     return Base.pairs(remaining)
 end
 
-_is_explicit_component(value) =
-    value isa CTSolvers.DOCP.AbstractDiscretizer ||
-    value isa CTSolvers.Modelers.AbstractNLPModeler ||
-    value isa CTSolvers.Solvers.AbstractNLPSolver
+_is_explicit_component(value, families=_descriptive_families()) =
+    any(T -> value isa T, values(families))
+
+"""
+$(TYPEDSIGNATURES)
+
+Return the names of the options accepted directly by `solve` in explicit mode:
+action options (with their aliases) plus the component keywords.
+
+Derived from [`_descriptive_action_defs`](@ref) and [`_descriptive_families`](@ref)
+so the list stays in sync with descriptive mode.
+"""
+function _explicit_option_names()
+    names = String[]
+    for def in _descriptive_action_defs()
+        push!(names, string(def.name))
+        append!(names, string.(def.aliases))
+    end
+    append!(names, string.(keys(_descriptive_families())))
+    return names
+end
 
 """
 $(TYPEDSIGNATURES)
@@ -24,23 +44,17 @@ $(TYPEDSIGNATURES)
 Validate keyword arguments left over after explicit solve components and action
 options have been extracted.
 """
-function _validate_explicit_options(kwargs, discretizer, modeler, solver)
-    strategies = (
-        (:discretizer, discretizer),
-        (:modeler, modeler),
-        (:solver, solver),
-    )
-
+function _validate_explicit_options(kwargs, components::NamedTuple)
     for (option, _) in kwargs
         owners = [
-            family for (family, strategy) in strategies if
+            family for (family, strategy) in pairs(components) if
             CTBase.Strategies.has_option(strategy, option)
         ]
 
         if isempty(owners)
             _throw_unknown_explicit_option(option)
         elseif length(owners) == 1
-            _throw_strategy_explicit_option(option, only(owners), strategies)
+            _throw_strategy_explicit_option(option, only(owners), components)
         else
             _throw_ambiguous_explicit_option(option, owners)
         end
@@ -49,8 +63,8 @@ function _validate_explicit_options(kwargs, discretizer, modeler, solver)
     return nothing
 end
 
-function _throw_strategy_explicit_option(option, owner, strategies)
-    strategy = only(strategy for (family, strategy) in strategies if family === owner)
+function _throw_strategy_explicit_option(option, owner, components::NamedTuple)
+    strategy = components[owner]
     strategy_name = nameof(typeof(strategy))
     throw(
         CTBase.IncorrectArgument(
@@ -77,7 +91,7 @@ function _throw_ambiguous_explicit_option(option, owners)
 end
 
 function _throw_unknown_explicit_option(option)
-    action_options = "initial_guess, init, display, discretizer, modeler, solver"
+    action_options = join(_explicit_option_names(), ", ")
     throw(
         CTBase.IncorrectArgument(
             "Unknown option for solve in explicit mode";

--- a/src/helpers/explicit_validation.jl
+++ b/src/helpers/explicit_validation.jl
@@ -1,0 +1,90 @@
+"""
+$(TYPEDSIGNATURES)
+
+Return keyword arguments that are not explicit component instances or canonical
+component keywords.
+"""
+function _extract_explicit_component_kwargs(kwargs::Base.Pairs)
+    component_names = (:discretizer, :modeler, :solver)
+    remaining = NamedTuple(
+        key => value for (key, value) in kwargs if
+        key ∉ component_names && !_is_explicit_component(value)
+    )
+    return Base.pairs(remaining)
+end
+
+_is_explicit_component(value) =
+    value isa CTSolvers.DOCP.AbstractDiscretizer ||
+    value isa CTSolvers.Modelers.AbstractNLPModeler ||
+    value isa CTSolvers.Solvers.AbstractNLPSolver
+
+"""
+$(TYPEDSIGNATURES)
+
+Validate keyword arguments left over after explicit solve components and action
+options have been extracted.
+"""
+function _validate_explicit_options(kwargs, discretizer, modeler, solver)
+    strategies = (
+        (:discretizer, discretizer),
+        (:modeler, modeler),
+        (:solver, solver),
+    )
+
+    for (option, _) in kwargs
+        owners = [
+            family for (family, strategy) in strategies if
+            CTBase.Strategies.has_option(strategy, option)
+        ]
+
+        if isempty(owners)
+            _throw_unknown_explicit_option(option)
+        elseif length(owners) == 1
+            _throw_strategy_explicit_option(option, only(owners), strategies)
+        else
+            _throw_ambiguous_explicit_option(option, owners)
+        end
+    end
+
+    return nothing
+end
+
+function _throw_strategy_explicit_option(option, owner, strategies)
+    strategy = only(strategy for (family, strategy) in strategies if family === owner)
+    strategy_name = nameof(typeof(strategy))
+    throw(
+        CTBase.IncorrectArgument(
+            "Strategy option cannot be passed directly to solve in explicit mode";
+            got="option `$(option)` for $(owner)",
+            expected="options accepted by the solve action or explicit component instances",
+            suggestion="Construct $(strategy_name) with $(option)=... and pass it as `$(owner)` to solve",
+            context="solve explicit option validation",
+        ),
+    )
+end
+
+function _throw_ambiguous_explicit_option(option, owners)
+    owner_names = join(string.(owners), ", ")
+    throw(
+        CTBase.IncorrectArgument(
+            "Ambiguous strategy option in explicit mode";
+            got="option `$(option)` for $(owner_names)",
+            expected="an explicitly configured strategy instance",
+            suggestion="Construct the intended strategy with $(option)=... and pass it to solve",
+            context="solve explicit option validation",
+        ),
+    )
+end
+
+function _throw_unknown_explicit_option(option)
+    action_options = "initial_guess, init, display, discretizer, modeler, solver"
+    throw(
+        CTBase.IncorrectArgument(
+            "Unknown option for solve in explicit mode";
+            got="option `$(option)`",
+            expected="one of $(action_options)",
+            suggestion="Use a solve action option or configure the option when constructing a strategy",
+            context="solve explicit option validation",
+        ),
+    )
+end

--- a/src/solve/explicit.jl
+++ b/src/solve/explicit.jl
@@ -53,7 +53,7 @@ function solve_explicit(
 
     # Explicit mode does not route strategy-specific options.
     remaining_kwargs = _extract_explicit_component_kwargs(kwargs2)
-    _validate_explicit_options(remaining_kwargs, components...)
+    _validate_explicit_options(remaining_kwargs, components)
 
     # Single solve call with resolved components
     return CommonSolve.solve(

--- a/src/solve/explicit.jl
+++ b/src/solve/explicit.jl
@@ -34,15 +34,15 @@ function solve_explicit(
     init_raw, kwargs1 = _extract_action_kwarg(
         kwargs, _INITIAL_GUESS_ALIASES, _DEFAULT_INITIAL_GUESS
     )
-    display_val, _ = _extract_action_kwarg(kwargs1, (:display,), _DEFAULT_DISPLAY)
+    display_val, kwargs2 = _extract_action_kwarg(kwargs1, (:display,), _DEFAULT_DISPLAY)
 
     # Normalize initial guess
     normalized_init = CTModels.build_initial_guess(ocp, init_raw)
 
     # Extract typed components by abstract type
-    discretizer = _extract_kwarg(kwargs, CTSolvers.DOCP.AbstractDiscretizer)
-    modeler = _extract_kwarg(kwargs, CTSolvers.Modelers.AbstractNLPModeler)
-    solver = _extract_kwarg(kwargs, CTSolvers.Solvers.AbstractNLPSolver)
+    discretizer = _extract_kwarg(kwargs2, CTSolvers.DOCP.AbstractDiscretizer)
+    modeler = _extract_kwarg(kwargs2, CTSolvers.Modelers.AbstractNLPModeler)
+    solver = _extract_kwarg(kwargs2, CTSolvers.Solvers.AbstractNLPSolver)
 
     # Resolve components: use provided ones or complete via registry
     components = if _has_complete_components(discretizer, modeler, solver)
@@ -50,6 +50,10 @@ function solve_explicit(
     else
         _complete_components(discretizer, modeler, solver, registry)
     end
+
+    # Explicit mode does not route strategy-specific options.
+    remaining_kwargs = _extract_explicit_component_kwargs(kwargs2)
+    _validate_explicit_options(remaining_kwargs, components...)
 
     # Single solve call with resolved components
     return CommonSolve.solve(

--- a/test/suite/solve/test_explicit.jl
+++ b/test/suite/solve/test_explicit.jl
@@ -32,6 +32,8 @@ const SHOWTIMING = isdefined(Main, :TestOptions) ? Main.TestOptions.SHOWTIMING :
 struct MockOCP <: CTModels.AbstractModel end
 struct MockInit <: CTModels.AbstractInitialGuess end
 struct MockSolution <: CTModels.AbstractSolution end
+CTModels.build_initial_guess(::MockOCP, ::Nothing) = MockInit()
+CTModels.build_initial_guess(::MockOCP, init::MockInit) = init
 
 # ====================================================================
 # TEST PROBLEMS FOR INTEGRATION TESTS
@@ -52,6 +54,50 @@ end
 struct MockSolver <: CTSolvers.Solvers.AbstractNLPSolver
     options::CTBase.Strategies.StrategyOptions
 end
+
+function CTBase.Strategies.metadata(::Type{MockDiscretizer})
+    return CTBase.Strategies.StrategyMetadata(
+        CTBase.Options.OptionDefinition(;
+            name=:grid_size, type=Int, default=100, description="Grid size"
+        ),
+    )
+end
+
+function CTBase.Strategies.metadata(::Type{MockModeler})
+    return CTBase.Strategies.StrategyMetadata(
+        CTBase.Options.OptionDefinition(;
+            name=:backend, type=Symbol, default=:dense, description="Backend"
+        ),
+        CTBase.Options.OptionDefinition(;
+            name=:modeler_only, type=Bool, default=false, description="Modeler-only option"
+        ),
+    )
+end
+
+function CTBase.Strategies.metadata(::Type{MockSolver})
+    return CTBase.Strategies.StrategyMetadata(
+        CTBase.Options.OptionDefinition(;
+            name=:backend, type=Symbol, default=:cpu, description="Backend"
+        ),
+        CTBase.Options.OptionDefinition(;
+            name=:solver_only, type=Bool, default=false, description="Solver-only option"
+        ),
+    )
+end
+
+CTBase.Strategies.options(strategy::MockDiscretizer) = strategy.options
+CTBase.Strategies.options(strategy::MockModeler) = strategy.options
+CTBase.Strategies.options(strategy::MockSolver) = strategy.options
+
+MockDiscretizer(; kwargs...) = MockDiscretizer(
+    CTBase.Strategies.build_strategy_options(MockDiscretizer; kwargs...)
+)
+MockModeler(; kwargs...) = MockModeler(
+    CTBase.Strategies.build_strategy_options(MockModeler; kwargs...)
+)
+MockSolver(; kwargs...) = MockSolver(
+    CTBase.Strategies.build_strategy_options(MockSolver; kwargs...)
+)
 
 CommonSolve.solve(
     ::MockOCP, ::MockInit, ::MockDiscretizer, ::MockModeler, ::MockSolver; display::Bool
@@ -80,6 +126,129 @@ function test_explicit()
                 registry=registry,
             )
             Test.@test result isa MockSolution
+        end
+
+        # ================================================================
+        # EXPLICIT OPTION VALIDATION
+        # ================================================================
+        Test.@testset "Action options remain valid" begin
+            result = OptimalControl.solve_explicit(
+                ocp;
+                init=init,
+                discretizer=disc,
+                modeler=mod,
+                solver=sol,
+                display=false,
+                registry=registry,
+            )
+            Test.@test result isa MockSolution
+        end
+
+        Test.@testset "Dispatcher validates explicit options" begin
+            err = try
+                CommonSolve.solve(
+                    ocp;
+                    initial_guess=init,
+                    disc=MockDiscretizer(),
+                    modeler=MockModeler(),
+                    solver=MockSolver(),
+                    backend=:generic,
+                    display=false,
+                )
+                nothing
+            catch exception
+                exception
+            end
+            Test.@test err isa CTBase.IncorrectArgument
+            Test.@test occursin("backend", sprint(showerror, err))
+        end
+
+        Test.@testset "Strategy option suggests construction" begin
+            configured_disc = MockDiscretizer()
+            configured_mod = MockModeler()
+            configured_sol = MockSolver()
+            err = try
+                OptimalControl.solve_explicit(
+                    ocp;
+                    initial_guess=init,
+                    discretizer=configured_disc,
+                    modeler=configured_mod,
+                    solver=configured_sol,
+                    modeler_only=true,
+                    registry=registry,
+                )
+                nothing
+            catch exception
+                exception
+            end
+            Test.@test err isa CTBase.IncorrectArgument
+            message = sprint(showerror, err)
+            Test.@test occursin("modeler_only", message)
+            Test.@test occursin("MockModeler", message)
+            Test.@test occursin("Construct", message)
+        end
+
+        Test.@testset "Ambiguous strategy option is rejected" begin
+            err = try
+                OptimalControl.solve_explicit(
+                    ocp;
+                    initial_guess=init,
+                    discretizer=MockDiscretizer(),
+                    modeler=MockModeler(),
+                    solver=MockSolver(),
+                    backend=:generic,
+                    registry=registry,
+                )
+                nothing
+            catch exception
+                exception
+            end
+            Test.@test err isa CTBase.IncorrectArgument
+            message = sprint(showerror, err)
+            Test.@test occursin("backend", message)
+            Test.@test occursin("modeler", message)
+            Test.@test occursin("solver", message)
+        end
+
+        Test.@testset "Unknown explicit option is rejected" begin
+            err = try
+                OptimalControl.solve_explicit(
+                    ocp;
+                    initial_guess=init,
+                    discretizer=disc,
+                    modeler=mod,
+                    solver=sol,
+                    beep=:beep,
+                    registry=registry,
+                )
+                nothing
+            catch exception
+                exception
+            end
+            Test.@test err isa CTBase.IncorrectArgument
+            message = sprint(showerror, err)
+            Test.@test occursin("beep", message)
+            Test.@test occursin("initial_guess", message)
+            Test.@test occursin("display", message)
+        end
+
+        Test.@testset "bypass does not change explicit mode validation" begin
+            err = try
+                OptimalControl.solve_explicit(
+                    ocp;
+                    initial_guess=init,
+                    discretizer=MockDiscretizer(),
+                    modeler=MockModeler(),
+                    solver=MockSolver(),
+                    backend=CTBase.Strategies.bypass(:generic),
+                    registry=registry,
+                )
+                nothing
+            catch exception
+                exception
+            end
+            Test.@test err isa CTBase.IncorrectArgument
+            Test.@test occursin("backend", sprint(showerror, err))
         end
 
         # ================================================================


### PR DESCRIPTION
## Summary

- Reject unconsumed keyword arguments in explicit `solve` mode instead of silently ignoring them.
- Provide actionable errors for strategy-specific, ambiguous, and unknown options.
- Clarify in the explicit-mode documentation that strategy options must be configured at construction time.
- Add regression coverage for `backend`, unknown options, dispatcher validation, and `bypass`.

## Test plan

- [x] Targeted explicit solve tests: 28 passed.
- [x] Complete solve test suite: 562 passed.
- [x] Full package test suite: 2,184 passed; 2 expected optional-capability tests marked broken.
- [ ] Documentation build: blocked by existing CTLie and extension precompilation errors unrelated to this change.

Generated with [Devin](https://devin.ai)