### PR TITLE
docs: modelling — describe an optimal control problem

### DIFF
--- a/docs/reports/03-modelling.md
+++ b/docs/reports/03-modelling.md
@@ -217,11 +217,34 @@ Fixtures already exist and are tested: `test/problems/control_free.jl` (`Exponen
 
 ## Acceptance criteria
 
-- [ ] Every symbol in the `inspect.md` list appears on the page and executes.
-- [ ] `without-control.md` exists and both fixtures run, reproducing $p = 0.5$ and
+- [x] Every symbol in the `inspect.md` list appears on the page and executes.
+- [x] `without-control.md` exists and both fixtures run, reproducing $p = 0.5$ and
       $\omega = \pi/2$.
-- [ ] `functional-api.md` no longer contains an inline `@docs` block, and is under ~400 lines.
-- [ ] No page writes `OptimalControl.VectorField`-style qualification for an exported symbol;
+- [x] `functional-api.md` no longer contains an inline `@docs` block, and is under ~400 lines
+      (267).
+- [x] No page writes `OptimalControl.VectorField`-style qualification for an exported symbol;
       `PreModel` and `Model` *are* qualified, correctly.
-- [ ] The `@id math-formulation` anchor still resolves after the move.
-- [ ] `with-ai.md`'s prompt template points at the new DSL page URL.
+- [ ] ~~The `@id math-formulation` anchor still resolves after the move.~~ **Dropped by
+      decision, not implemented**: Documenter only recognises `@id` when the link is the sole
+      child of a *heading* node (`namedheader`, `expander_pipeline.jl`) — a standalone
+      `[](@id math-formulation)` anchor is not real Documenter syntax and was silently treated
+      as a broken link, caught by a full rebuild. No currently-built page references
+      `@ref math-formulation` (only `docs/attic/manual-macro-free.md`, not part of the live
+      build) so nothing breaks; kept only `@id modelling-formulation`, matching the sitemap
+      convention. `docs/reports/02-getting-started.md`'s mention of keeping this section on
+      `index.md` is a latent inconsistency with this PR's move — left for PR 11 to reconcile.
+- [x] `with-ai.md`'s prompt template points at the new DSL page URL, confirmed against the
+      actual built route (`/modelling/abstract-syntax`, no `.html` — DocumenterVitepress
+      clean URLs) via a full `docs/build/1` inspection, not just the source text.
+
+Verified by an independent full rebuild (`julia --project=docs docs/make.jl` +
+`npx vitepress build build/1`), not just re-checked against the diff: zero "undefined
+binding"/"no docs found"/"duplicate docs found" (regression check on PR 4), zero build
+errors, zero failed or un-expanded `@example` blocks on any of the six pages, zero unresolved
+`@ref`s originating from these pages. One genuine upstream bug found and filed in the
+process, unrelated to this PR's own content but triggered by it: `plot(sol)` throws
+`IncorrectArgument("a VBox needs at least one child")` on the *default* call for any plain
+direct-solved solution once `layout=:split`'s default description includes `:costate`
+([`CTModels.jl#392`](https://github.com/control-toolbox/CTModels.jl/issues/392)) — worked
+around in both affected pages with an explicit `plot(sol, :state, :control)`/`plot(sol,
+:state)` description.

--- a/docs/reports/README.md
+++ b/docs/reports/README.md
@@ -52,7 +52,7 @@ Status legend: ⬜ not started · 🟡 in progress · ✅ merged
 | 2 | [`docs: infrastructure`](https://github.com/control-toolbox/OptimalControl.jl/pull/854) | build + skeleton | [`01`](01-infrastructure.md) | 1 | ✅ |
 | 3 | [`feat: deprecation shims`](https://github.com/control-toolbox/OptimalControl.jl/pull/855) | `src/deprecated.jl` | [`10`](10-migration.md) §1 | 1 | ✅ |
 | 4 | [`docs: API reference`](https://github.com/control-toolbox/OptimalControl.jl/pull/856) | API reference | [`09`](09-api-reference.md) | 2 | ✅ |
-| 5 | `docs: modelling` | Modelling | [`03`](03-modelling.md) | 2 | 🟡 branch ready, build verified green, not yet opened as a PR |
+| 5 | [`docs: modelling`](https://github.com/control-toolbox/OptimalControl.jl/pull/865) | Modelling | [`03`](03-modelling.md) | 2 | 🟡 in review |
 | 6 | `docs: solve` | Solve (direct) | [`04`](04-solve-direct.md) | 5 | ⬜ |
 | 7 | `docs: results` | Results | [`07`](07-results.md) | 6 | ⬜ |
 | 8 | `docs: flows` | Flows (indirect) | [`05`](05-flows-indirect.md) | 6 | ⬜ |

--- a/docs/reports/README.md
+++ b/docs/reports/README.md
@@ -52,7 +52,7 @@ Status legend: ⬜ not started · 🟡 in progress · ✅ merged
 | 2 | [`docs: infrastructure`](https://github.com/control-toolbox/OptimalControl.jl/pull/854) | build + skeleton | [`01`](01-infrastructure.md) | 1 | ✅ |
 | 3 | [`feat: deprecation shims`](https://github.com/control-toolbox/OptimalControl.jl/pull/855) | `src/deprecated.jl` | [`10`](10-migration.md) §1 | 1 | ✅ |
 | 4 | [`docs: API reference`](https://github.com/control-toolbox/OptimalControl.jl/pull/856) | API reference | [`09`](09-api-reference.md) | 2 | ✅ |
-| 5 | `docs: modelling` | Modelling | [`03`](03-modelling.md) | 2 | ⬜ |
+| 5 | `docs: modelling` | Modelling | [`03`](03-modelling.md) | 2 | 🟡 branch ready, build verified green, not yet opened as a PR |
 | 6 | `docs: solve` | Solve (direct) | [`04`](04-solve-direct.md) | 5 | ⬜ |
 | 7 | `docs: results` | Results | [`07`](07-results.md) | 6 | ⬜ |
 | 8 | `docs: flows` | Flows (indirect) | [`05`](05-flows-indirect.md) | 6 | ⬜ |

--- a/docs/src/assets/Manifest.toml
+++ b/docs/src/assets/Manifest.toml
@@ -1894,7 +1894,7 @@ version = "0.5.6+0"
 
 [[deps.OptimalControl]]
 deps = ["ADNLPModels", "CTBase", "CTDirect", "CTFlows", "CTLie", "CTModels", "CTParser", "CTSolvers", "CommonSolve", "DifferentiationInterface", "DocStringExtensions", "ExaModels", "ForwardDiff", "LinearAlgebra", "NLPModels", "RecipesBase", "Reexport", "SolverCore"]
-path = ".."
+git-tree-sha1 = "f87943a0923ddcdfe29fe3ec4e12d01786d4ef4a"
 uuid = "5f98b655-cc9a-415a-b60e-744165666948"
 version = "2.1.0-beta"
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -104,7 +104,7 @@ _downloads_toml(".") # hide
 ```
 
 ```@raw html
-<details style="margin-bottom: 0.5em; margin-top: 1em;"><summary>ℹ️ Version info</summary>
+<details style="margin-bottom: 0.5em; margin-top: 1em;"><summary style="margin-bottom: 0px; margin-top: 0px;">ℹ️ Version info</summary>
 ```
 
 ```@example main
@@ -116,7 +116,7 @@ versioninfo() # hide
 ```
 
 ```@raw html
-<details style="margin-bottom: 0.5em;"><summary>📦 Package status</summary>
+<details style="margin-bottom: 0.5em;"><summary style="margin-bottom: 0px; margin-top: 0px;">📦 Package status</summary>
 ```
 
 ```@example main
@@ -128,7 +128,7 @@ Pkg.status() # hide
 ```
 
 ```@raw html
-<details style="margin-bottom: 0.5em;"><summary>📚 Complete manifest</summary>
+<details style="margin-bottom: 0.5em;"><summary style="margin-bottom: 0px; margin-top: 0px;">📚 Complete manifest</summary>
 ```
 
 ```@example main

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -43,56 +43,12 @@ plot(sol)
 - The `solve` function has many options. See the [solve overview](@ref solve-overview).  
 - The `plot` function is flexible. See the [plot guide](@ref results-plot).
 
-## [Mathematical formulation](@id math-formulation)
+## Mathematical formulation
 
-An optimal control problem (OCP) with fixed initial and final times can be described as minimising the cost functional (in Bolza form)
-
-```math
-J(x, u) = g(x(t_0), x(t_f)) + \int_{t_0}^{t_f} f^{0}(t, x(t), u(t))\,\mathrm{d}t
-```
-
-where the state $x$ and the control $u$ are functions of time $t$, subject for $t \in [t_0, t_f]$ to the differential constraint
-
-```math
-\dot{x}(t) = f(t, x(t), u(t))
-```
-
-and other constraints such as
-
-```math
-\begin{array}{llcll}
-x_{\mathrm{lower}} & \le & x(t)              & \le & x_{\mathrm{upper}}, \\
-u_{\mathrm{lower}} & \le & u(t)              & \le & u_{\mathrm{upper}}, \\
-c_{\mathrm{lower}} & \le & c(t, x(t), u(t))  & \le & c_{\mathrm{upper}}, \\
-b_{\mathrm{lower}} & \le & b(x(t_0), x(t_f)) & \le & b_{\mathrm{upper}}.
-\end{array}
-```
-
-If $g = 0$, the cost is said to be in **Lagrange form**; if $f^0 = 0$, it is in **Mayer form**.
-
-**Free times and extra variables**
-
-The initial time $t_0$ and the final time $t_f$ may also be free, that is part of the optimisation variables:
-
-```math
-J(x, u, t_0, t_f) \to \min.
-```
-
-More generally, a vector $v \in \mathbb{R}^k$ of $k$ additional variables can be introduced (it may contain $t_0$, $t_f$, or any other free parameter). The cost, dynamics, and constraints then all depend on $v$:
-
-```math
-J(x, u, v) = g(x(t_0), x(t_f), v) + \int_{t_0}^{t_f} f^{0}(t, x(t), u(t), v)\,\mathrm{d}t \to \min,
-```
-
-```math
-\dot{x}(t) = f(t, x(t), u(t), v),
-```
-
-with, in addition, box constraints on $v$:
-
-```math
-v_{\mathrm{lower}} \le v \le v_{\mathrm{upper}}.
-```
+Optimal control problems are stated in Bolza form — a cost functional combining a terminal
+(Mayer) and an integral (Lagrange) term, subject to dynamics and box/path/boundary
+constraints, with optionally free times and extra optimisation variables. See
+[Formulation](@ref modelling-formulation) for the full mathematical setting.
 
 ## Citing us
 

--- a/docs/src/modelling/abstract-syntax.md
+++ b/docs/src/modelling/abstract-syntax.md
@@ -1,4 +1,660 @@
 # [Abstract syntax](@id modelling-abstract-syntax)
 
-!!! warning "Under construction"
-    This page is being written. See the [specification reports](https://github.com/control-toolbox/OptimalControl.jl/tree/main/docs/reports).
+```@meta
+Draft = false
+```
+
+The full grammar of OptimalControl.jl's small *Domain Specific Language* is given below. The idea is to use a syntax that is
+
+- pure Julia (and, as such, effortlessly analysed by the standard Julia parser),
+- as close as possible to the mathematical description of an optimal control problem (see [Formulation](@ref modelling-formulation)).
+
+While the syntax will be transparent to those users familiar with Julia expressions (`Expr`'s), we provide examples for every case that should be widely understandable. Abstract definitions use the macro [`@def`](@ref).
+
+## [Variable](@id modelling-abstract-syntax-variable)
+
+```julia
+:( $v ∈ R^$q, variable )
+:( $v ∈ R   , variable )
+```
+
+A variable (only one is allowed) is a finite dimensional vector or reals that will be *optimised* along with state and control values. To define an (almost empty!) optimal control problem, named `ocp`, having a dimension two variable named `v`, do the following:
+
+```julia
+@def begin
+    v ∈ R², variable
+    ...
+end
+```
+
+!!! warning
+
+    - Note that the full code of the definition above is not provided (hence the `...`). The same is true for most examples below (only those without `...` are indeed complete).
+    - Also note that problem definitions must at least include definitions for time, state, dynamics and cost. The control declaration is optional (see [Problems without a control](@ref modelling-abstract-syntax-control-free)).
+
+Aliases `v₁`, `v₂` (and `v1`, `v2`) are automatically defined and can be used in subsequent expressions instead of `v[1]` and `v[2]`. The user can also define her own aliases for the components (one alias per dimension):
+
+```julia
+@def begin
+    v = (a, b) ∈ R², variable
+    ...
+end
+```
+
+A one dimensional variable can be declared according to
+
+```julia
+@def begin
+    v ∈ R, variable
+    ...
+end
+```
+
+!!! warning
+    Aliases during definition of variable, state or control are only allowed for multidimensional (dimension two or more) cases. Something like `u = T ∈ R, control` is not allowed... and useless (directly write `T ∈ R, control`).
+
+## Time
+
+```julia
+:( $t ∈ [$t0, $tf], time )
+```
+
+The independent variable or *time* is a scalar bound to a given interval. Its name is arbitrary.
+
+```julia
+t0 = 1
+tf = 5
+@def begin
+    t ∈ [t0, tf], time
+    ...
+end
+```
+
+One (or even the two bounds) can be variable, typically for minimum time problems (see [Mayer cost](@ref modelling-abstract-syntax-mayer) section):
+
+```julia
+@def begin
+    v = (T, λ) ∈ R², variable
+    t ∈ [0, T], time
+    ...
+end
+```
+
+## [State](@id modelling-abstract-syntax-state)
+
+```julia
+:( $x ∈ R^$n, state )
+:( $x ∈ R   , state )
+```
+
+The state declaration defines the name and the dimension of the state:
+
+```julia
+@def begin
+    x ∈ R⁴, state
+    ...
+end
+```
+
+As for the variable, there are automatic aliases (`x₁` and `x1` for `x[1]`, *etc.*) and the user can define her own aliases (one per scalar component of the state):
+
+```julia
+@def begin
+    x = (q₁, q₂, v₁, v₂) ∈ R⁴, state
+    ...
+end
+```
+
+## [Control](@id modelling-abstract-syntax-control)
+
+```julia
+:( $u ∈ R^$m, control )
+:( $u ∈ R   , control )
+```
+
+The control declaration defines the name and the dimension of the control:
+
+```julia
+@def begin
+    u ∈ R², control
+    ...
+end
+```
+
+As before, there are automatic aliases (`u₁` and `u1` for `u[1]`, *etc.*) and the user can define her own aliases (one per scalar component of the state):
+
+```julia
+@def begin
+    u = (α, β) ∈ R², control
+    ...
+end
+```
+
+!!! note
+    One dimensional variable, state or control are treated as scalars (`Real`), not vectors (`Vector`). In Julia, for `x::Real`, it is possible to write `x[1]` (and `x[1][1]`...) so it is OK (though useless) to write `x₁`, `x1` or `x[1]` instead of simply `x` to access the corresponding value. Conversely it is *not* OK to use such an `x` as a vector, for instance as in `...f(x)...` where `f(x::Vector{T}) where {T <: Real}`. This same convention applies on the [functional API](@ref modelling-functional-api): a dimension-1 quantity is a scalar, not a length-1 vector — see [Shapes in callbacks](@ref modelling-functional-api-shapes).
+
+## [Problems without a control](@id modelling-abstract-syntax-control-free)
+
+The control declaration is **optional**. You can define problems without control for:
+
+- **Parameter estimation**: identify unknown parameters in the dynamics from observed data,
+- **Dynamic optimisation**: optimise constant parameters subject to ODE constraints.
+
+For example, to estimate a growth rate parameter:
+
+```julia
+@def begin
+    p ∈ R, variable              # parameter to estimate
+    t ∈ [0, 10], time
+    x ∈ R, state
+    x(0) == 2.0
+    ẋ(t) == p * x(t)             # dynamics depends on p
+    ∫(x(t) - data(t))² → min     # fit to observed data
+end
+```
+
+Or to optimise the pulsation of a harmonic oscillator:
+
+```julia
+@def begin
+    ω ∈ R, variable              # pulsation to optimize
+    t ∈ [0, 1], time
+    x = (q, v) ∈ R², state
+    q(0) == 1.0
+    v(0) == 0.0
+    q(1) == 0.0                  # final condition
+    ẋ(t) == [v(t), -ω²*q(t)]    # harmonic oscillator
+    ω² → min                     # minimize pulsation
+end
+```
+
+There is no dedicated syntax for "no control": omitting the control declaration entirely *is*
+the syntax — do not declare a dummy `u ∈ R, control` with `u(t) == 0`, and never write
+`control!(pre, 0)` on the [functional API](@ref modelling-functional-api), which is rejected
+as an error. See [Problems without a control](@ref modelling-without-control) for the full
+worked examples above, solved both directly and indirectly.
+
+## [Dynamics](@id modelling-abstract-syntax-dynamics)
+
+```julia
+:( ∂($x)($t) == $e1 )
+```
+
+The dynamics is given in the standard vectorial ODE form:
+
+```math
+    \dot{x}(t) = f([t, ]x(t)[, u(t)][, v])
+```
+
+depending on whether it is autonomous / with a variable or not (the parser will detect time and variable dependences,
+which entails that time, state and variable must be declared prior to dynamics - an error will be issued otherwise). The symbol `∂`, or the dotted state name
+(`ẋ`), or the keyword `derivative` can be used:
+
+```julia
+@def begin
+    t ∈ [0, 1], time
+    x ∈ R², state
+    u ∈ R, control
+    ∂(x)(t) == [x₂(t), u(t)]
+    ...
+end
+```
+
+or
+
+```julia
+@def begin
+    t ∈ [0, 1], time
+    x ∈ R², state
+    u ∈ R, control
+    ẋ(t) == [x₂(t), u(t)]
+    ...
+end
+```
+
+or
+
+```julia
+@def begin
+    t ∈ [0, 1], time
+    x ∈ R², state
+    u ∈ R, control
+    derivative(x)(t) == [x₂(t), u(t)]
+    ...
+end
+```
+
+Any Julia code can be used, so the following is also OK:
+
+```julia
+ocp = @def begin
+    t ∈ [0, 1], time
+    x ∈ R², state
+    u ∈ R, control
+    ẋ(t) == F₀(x(t)) + u(t) * F₁(x(t))
+    ...
+end
+
+F₀(x) = [x[2], 0]
+F₁(x) = [0, 1]
+```
+
+!!! note
+    The vector fields `F₀` and `F₁` can be defined afterwards, as they only need to be available when the dynamics will be evaluated.
+
+While it is also possible to declare the dynamics component after component (see below), one may equivalently use *aliases* (check the relevant [aliases](@ref modelling-abstract-syntax-aliases) section below):
+
+```julia
+@def damped_integrator begin
+    tf ∈ R, variable
+    t ∈ [0, tf], time
+    x = (q, v) ∈ R², state
+    u ∈ R, control
+    q̇ = v(t)
+    v̇ = u(t) - c(t)
+    ẋ(t) == [q̇, v̇]
+    ...
+end
+```
+
+## [Dynamics (coordinatewise)](@id modelling-abstract-syntax-dynamics-coord)
+
+```julia
+:( ∂($x[$i])($t) == $e1 )
+```
+
+The dynamics can also be declared coordinate by coordinate. The previous example can be written as
+
+```julia
+@def damped_integrator begin
+    tf ∈ R, variable
+    t ∈ [0, tf], time
+    x = (q, v) ∈ R², state
+    u ∈ R, control
+    ∂(q)(t) == v(t)
+    ∂(v)(t) == u(t) - c(t)
+    ...
+end
+```
+
+## [Constraints](@id modelling-abstract-syntax-constraints)
+
+```julia
+:( $e1 == $e2        )
+:( $e1 ≤  $e2 ≤  $e3 )
+:(        $e2 ≤  $e3 )
+:( $e3 ≥  $e2 ≥  $e1 )
+:( $e2 ≥  $e1        )
+```
+
+Admissible constraints can be
+
+- of five types: boundary, variable, control, state, mixed (the last three ones are *path* constraints, that is constraints evaluated all times)
+- linear (ranges) or nonlinear (not ranges),
+- equalities or (one or two-sided) inequalities.
+
+Boundary conditions are detected when the expression contains evaluations of the state at initial and / or final time bounds (*e.g.*, `x(0)`), and may not involve the control. Conversely control, state or mixed constraints will involve control, state or both evaluated at the declared time (*e.g.*, `x(t) + u(t)`).
+Other combinations should be detected as incorrect by the parser. The variable may be involved in any of the four previous constraints. Constraints involving the variable only are variable constraints, either linear or nonlinear.
+In the example below, there are
+
+- two linear boundary constraints,
+- one linear variable constraint,
+- one linear state constraint,
+- one (two-sided) nonlinear control constraint.
+
+```julia
+@def begin
+    tf ∈ R, variable
+    t ∈ [0, tf], time
+    x ∈ R², state
+    u ∈ R, control
+    x(0) == [-1, 0]
+    x(tf) == [0, 0]
+    ẋ(t) == [x₂(t), u(t)]
+    tf ≥ 0
+    x₂(t) ≤ 1
+    0.1 ≤ u(t)^2 ≤ 1
+    ...
+end
+```
+
+!!! note "Duplicate box constraints"
+    If the same scalar component of the state, control or variable appears in several **box** constraints (linear range constraints), the effective bounds are the **intersection** of all declared bounds: the effective lower bound is the maximum of declared lower bounds, and the effective upper bound is the minimum of declared upper bounds. A warning is emitted, and an error is thrown if the resulting interval is empty. See [Duplicate box constraints](@ref modelling-abstract-syntax-box-dedup) below.
+
+!!! note
+    Symbols like `<=` or `>=` are also authorised:
+
+```julia
+@def begin
+    tf ∈ R, variable
+    t ∈ [0, tf], time
+    x ∈ R², state
+    u ∈ R, control
+    x(0) == [-1, 0]
+    x(tf) == [0, 0]
+    ẋ(t) == [x₂(t), u(t)]
+    tf >= 0
+    x₂(t) <= 1
+    0.1 ≤ u(t)^2 <= 1
+    ...
+end
+```
+
+!!! warning
+    Write either `u(t)^2` or `(u^2)(t)`, not `u^2(t)` since in Julia the latter means `u^(2t)`. Moreover,
+    in the case of equalities or of one-sided inequalities, the control and / or the state must belong to the *left-hand side*. The following will error:
+
+    ```@setup main-repl
+    using OptimalControl
+    ```
+
+    ```@repl main-repl
+    @def begin
+        t ∈ [0, 2], time
+        x ∈ R², state
+        u ∈ R, control
+        x(0) == [-1, 0]
+        x(2) == [0, 0]
+        ẋ(t) == [x₂(t), u(t)]
+        1 ≤ x₂(t)
+        -1 ≤ u(t) ≤ 1
+    end
+    ```
+
+!!! warning
+    Constraint bounds must be *effective*, that is must not depend on a variable. For instance, instead of
+
+    ```julia
+    o = @def begin
+        v ∈ R, variable
+        t ∈ [0, 1], time
+        x ∈ R², state
+        u ∈ R, control
+        -1 ≤ v ≤ 1
+        x₁(0) == -1
+        x₂(0) == v # wrong: the bound is not effective (as it depends on the variable)
+        x(1) == [0, 0]
+        ẋ(t) == [x₂(t), u(t)]
+        ∫( 0.5u(t)^2 ) → min
+    end
+    ```
+
+    write
+
+    ```julia
+    o = @def begin
+        v ∈ R, variable
+        t ∈ [0, 1], time
+        x ∈ R², state
+        u ∈ R, control
+        -1 ≤ v ≤ 1
+        x₁(0) == -1
+        x₂(0) - v == 0 # OK: the boundary constraint may involve the variable
+        x(1) == [0, 0]
+        ẋ(t) == [x₂(t), u(t)]
+        ∫( 0.5u(t)^2 ) → min
+    end
+    ```
+
+### [Duplicate box constraints](@id modelling-abstract-syntax-box-dedup)
+
+**Box constraints** are linear range constraints on a single scalar component of the state, control or variable — that is, constraints of the form `lb ≤ x_i(t) ≤ ub`, `u_i(t) ≤ ub`, `v_i ≥ lb`, etc. (nonlinear path constraints are *not* concerned by this section).
+
+When the **same scalar component** is targeted by several box-constraint declarations, OptimalControl does **not** keep them as separate constraints. Instead, it merges them by taking the **intersection** of all declared bounds:
+
+- the effective lower bound is `max` of all declared lower bounds,
+- the effective upper bound is `min` of all declared upper bounds,
+- a single `@warn` is emitted per duplicated component, listing every contributing label,
+- all labels that declared the component are preserved as **aliases** (accessible via the `aliases` field of [`state_constraints_box`](@ref), [`control_constraints_box`](@ref) and [`variable_constraints_box`](@ref); see [Inspect a problem](@ref modelling-inspect)),
+- if the intersection is empty (`max(lbs) > min(ubs)`), an `IncorrectArgument` exception is thrown.
+
+For instance,
+
+```julia
+@def begin
+    t ∈ [0, 1], time
+    x = (q, v) ∈ R², state
+    u ∈ R, control
+    0 ≤ q(t) ≤ 2, (q_wide)
+    1 ≤ q(t) ≤ 3, (q_tight)
+    ẋ(t) == [v(t), u(t)]
+    ...
+end
+```
+
+yields the effective constraint `1 ≤ q(t) ≤ 2`, with `aliases = [:q_wide, :q_tight]` for that component, and a warning reporting both labels.
+
+Conversely, the following declares an empty feasible set and raises an error at build time:
+
+```julia
+@def begin
+    t ∈ [0, 1], time
+    x = (q, v) ∈ R², state
+    u ∈ R, control
+    0 ≤ q(t) ≤ 1, (low)
+    2 ≤ q(t) ≤ 3, (high) # max(lbs)=2 > min(ubs)=1 ⇒ IncorrectArgument
+    ẋ(t) == [v(t), u(t)]
+    ...
+end
+```
+
+## [Mayer cost](@id modelling-abstract-syntax-mayer)
+
+```julia
+:( $e1 → min )
+:( $e1 → max )
+```
+
+Mayer costs are defined in a similar way to boundary conditions and follow the same rules. The symbol `→` is used
+to denote minimisation or maximisation, the latter being treated by minimising the opposite cost. (The symbol `=>` can also be used.)
+
+```@repl main-repl
+@def begin
+    tf ∈ R, variable
+    t ∈ [0, tf], time
+    x = (q, v) ∈ R², state
+    u ∈ R, control
+    tf ≥ 0
+    -1 ≤ u(t) ≤ 1
+    q(0) == 1
+    v(0) == 2
+    q(tf) == 0
+    v(tf) == 0
+    0 ≤ q(t) ≤ 5
+   -2 ≤ v(t) ≤ 3
+    ẋ(t) == [v(t), u(t)]
+    tf → min
+end
+```
+
+## Lagrange cost
+
+```julia
+:(       ∫($e1) → min )
+:(     - ∫($e1) → min )
+:( $e1 * ∫($e2) → min )
+:(       ∫($e1) → max )
+:(     - ∫($e1) → max )
+:( $e1 * ∫($e2) → max )
+```
+
+Lagrange (integral) costs are defined used the symbol `∫`, *with parentheses*. The keyword `integral` can also be used:
+
+```julia
+@def begin
+    t ∈ [0, 1], time
+    x = (q, v) ∈ R², state
+    u ∈ R, control
+    0.5∫(q(t) + u(t)^2) → min
+    ...
+end
+```
+
+or
+
+```julia
+@def begin
+    t ∈ [0, 1], time
+    x = (q, v) ∈ R², state
+    u ∈ R, control
+    0.5integral(q(t) + u(t)^2) → min
+    ...
+end
+```
+
+The integration range is implicitly equal to the time range, so the cost above is to be understood as
+
+```math
+\frac{1}{2} \int_0^1 \left( q(t) + u^2(t) \right) \mathrm{d}t \to \min.
+```
+
+As for the dynamics, the parser will detect whether the integrand depends or not on time (autonomous / non-autonomous case).
+
+## Bolza cost
+
+```julia
+:( $e1 +       ∫($e2)       → min )
+:( $e1 + $e2 * ∫($e3)       → min )
+:( $e1 -       ∫($e2)       → min )
+:( $e1 - $e2 * ∫($e3)       → min )
+:( $e1 +       ∫($e2)       → max )
+:( $e1 + $e2 * ∫($e3)       → max )
+:( $e1 -       ∫($e2)       → max )
+:( $e1 - $e2 * ∫($e3)       → max )
+:(             ∫($e2) + $e1 → min )
+:(       $e2 * ∫($e3) + $e1 → min )
+:(             ∫($e2) - $e1 → min )
+:(       $e2 * ∫($e3) - $e1 → min )
+:(             ∫($e2) + $e1 → max )
+:(       $e2 * ∫($e3) + $e1 → max )
+:(             ∫($e2) - $e1 → max )
+:(       $e2 * ∫($e3) - $e1 → max )
+```
+
+Quite readily, Mayer and Lagrange costs can be combined into general Bolza costs. For instance as follows:
+
+```julia
+@def begin
+    p = (t0, tf) ∈ R², variable
+    t ∈ [t0, tf], time
+    x = (q, v) ∈ R², state
+    u ∈ R², control
+    (tf - t0) + 0.5∫(c(t) * u(t)^2) → min
+    ...
+end
+```
+
+!!! warning
+    The expression must be the sum of two terms (plus, possibly, a scalar factor before the integral), not *more*, so mind the parentheses. For instance, the following errors:
+
+    ```julia
+    @def begin
+        p = (t0, tf) ∈ R², variable
+        t ∈ [t0, tf], time
+        x = (q, v) ∈ R², state
+        u ∈ R², control
+        (tf - t0) + q(tf) + 0.5∫( c(t) * u(t)^2 ) → min
+        ...
+    end
+    ```
+
+    The correct syntax is
+
+    ```julia
+    @def begin
+        p = (t0, tf) ∈ R², variable
+        t ∈ [t0, tf], time
+        x = (q, v) ∈ R², state
+        u ∈ R², control
+        ((tf - t0) + q(tf)) + 0.5∫( c(t) * u(t)^2 ) → min
+        ...
+    end
+    ```
+
+## [Aliases](@id modelling-abstract-syntax-aliases)
+
+```julia
+:( $a = $e1 )
+```
+
+The single `=` symbol is used to define not a constraint but an alias, that is a purely syntactic replacement. There are some automatic aliases, *e.g.* `x₁` and `x1` for `x[1]` if `x` is the state (same for variable and control, for indices comprised between 1 and 9), and we have also seen that the user can define her own aliases when declaring the [variable](@ref modelling-abstract-syntax-variable), [state](@ref modelling-abstract-syntax-state) and [control](@ref modelling-abstract-syntax-control). Arbitrary aliases can be further defined, as below (compare with previous examples in the [dynamics](@ref modelling-abstract-syntax-dynamics) section):
+
+```julia
+@def begin
+    t ∈ [0, 1], time
+    x ∈ R², state
+    u ∈ R, control
+    F₀ = [x₂(t), 0]
+    F₁ = [0, 1]
+    ẋ(t) == F₀ + u(t) * F₁
+    ...
+end
+```
+
+!!! warning
+    Such aliases do *not* define any additional function and are just replaced textually by the parser. In particular, they cannot be used outside the `@def` `begin ... end` block. Conversely, constants and functions used within the `@def` block must be defined outside and before this block.
+
+!!! hint
+    You can rely on a trace mode for the macro `@def` to look at your code after expansions of the aliases using the `@def ocp ...` syntax and adding `true` after your `begin ... end` block:
+
+    ```@repl main-repl
+    @def damped_integrator begin
+        tf ∈ R, variable
+        t ∈ [0, tf], time
+        x = (q, v) ∈ R², state
+        u ∈ R, control
+        q̇ = v(t)
+        v̇ = u(t) - c(t)
+        ẋ(t) == [q̇, v̇]
+    end true;
+    ```
+
+!!! warning
+    The dynamics of an OCP is indeed a particular constraint, be careful to use `==` and not a single `=` that would try to define an alias:
+
+    ```@repl main-repl
+    double_integrator = @def begin
+        tf ∈ R, variable
+        t ∈ [0, tf], time
+        x = (q, v) ∈ R², state
+        u ∈ R, control
+        q̇ = v
+        v̇ = u
+        ẋ(t) = [q̇, v̇]
+    end
+    ```
+
+## Misc
+
+- Declarations (of variable - if any -, time, state and control - if any -) must be done first. Then, dynamics, constraints and cost can be introduced in an arbitrary order.
+- It is possible to provide numbers / labels (as in math equations) for the constraints to improve readability (this is mostly for future use, typically to retrieve the Lagrange multiplier associated with the discretisation of a given constraint):
+
+```julia
+@def damped_integrator begin
+    tf ∈ R, variable
+    t ∈ [0, tf], time
+    x = (q, v) ∈ R², state
+    u ∈ R, control
+    tf ≥ 0, (1)
+    q(0) == 2, (♡)
+    q̇ = v(t)
+    v̇ = u(t) - c(t)
+    ẋ(t) == [q̇, v̇]
+    x(t).^2  ≤ [1, 2], (state_con)
+    ...
+end
+```
+
+- Parsing errors should be explicit enough (with line number in the `@def` `begin ... end` block indicated).
+- Check tutorials and applications in the documentation for further use.
+
+## [Known issues](@id modelling-abstract-syntax-known-issues)
+
+- [Reverse over forward AD issues with ADNLP](https://github.com/control-toolbox/OptimalControl.jl/issues/481#issuecomment-3471352183)
+
+## See also
+
+- [Formulation](@ref modelling-formulation) — the mathematics this syntax encodes.
+- [Functional API](@ref modelling-functional-api) — build the same model without the macro.
+- [Problems without a control](@ref modelling-without-control) — the control-free case, worked in full.
+- [Inspect a problem](@ref modelling-inspect) — read a built model back.

--- a/docs/src/modelling/formulation.md
+++ b/docs/src/modelling/formulation.md
@@ -1,4 +1,64 @@
 # [Formulation](@id modelling-formulation)
 
-!!! warning "Under construction"
-    This page is being written. See the [specification reports](https://github.com/control-toolbox/OptimalControl.jl/tree/main/docs/reports).
+```@meta
+Draft = false
+```
+
+An optimal control problem (OCP) with fixed initial and final times can be described as minimising the cost functional (in Bolza form)
+
+```math
+J(x, u) = g(x(t_0), x(t_f)) + \int_{t_0}^{t_f} f^{0}(t, x(t), u(t))\,\mathrm{d}t
+```
+
+where the state $x$ and the control $u$ are functions of time $t$, subject for $t \in [t_0, t_f]$ to the differential constraint
+
+```math
+\dot{x}(t) = f(t, x(t), u(t))
+```
+
+and other constraints such as
+
+```math
+\begin{array}{llcll}
+x_{\mathrm{lower}} & \le & x(t)              & \le & x_{\mathrm{upper}}, \\
+u_{\mathrm{lower}} & \le & u(t)              & \le & u_{\mathrm{upper}}, \\
+c_{\mathrm{lower}} & \le & c(t, x(t), u(t))  & \le & c_{\mathrm{upper}}, \\
+b_{\mathrm{lower}} & \le & b(x(t_0), x(t_f)) & \le & b_{\mathrm{upper}}.
+\end{array}
+```
+
+If $g = 0$, the cost is said to be in **Lagrange form**; if $f^0 = 0$, it is in **Mayer form**.
+
+## Free times and extra variables
+
+The initial time $t_0$ and the final time $t_f$ may also be free, that is part of the optimisation variables:
+
+```math
+J(x, u, t_0, t_f) \to \min.
+```
+
+More generally, a vector $v \in \mathbb{R}^k$ of $k$ additional variables can be introduced (it may contain $t_0$, $t_f$, or any other free parameter). The cost, dynamics, and constraints then all depend on $v$:
+
+```math
+J(x, u, v) = g(x(t_0), x(t_f), v) + \int_{t_0}^{t_f} f^{0}(t, x(t), u(t), v)\,\mathrm{d}t \to \min,
+```
+
+```math
+\dot{x}(t) = f(t, x(t), u(t), v),
+```
+
+with, in addition, box constraints on $v$:
+
+```math
+v_{\mathrm{lower}} \le v \le v_{\mathrm{upper}}.
+```
+
+## The control-free case
+
+Nothing above requires a control to be present: taking $m = 0$ (no $u$) is a legitimate degenerate case, used to fit or optimise parameters of a dynamical system rather than to steer it. See [Problems without a control](@ref modelling-without-control) for how to declare and solve such problems.
+
+## See also
+
+- [Abstract syntax (`@def`)](@ref modelling-abstract-syntax) — write this formulation directly as Julia code.
+- [Functional API](@ref modelling-functional-api) — build the same model without the macro.
+- [Problems without a control](@ref modelling-without-control) — the $m = 0$ case.

--- a/docs/src/modelling/functional-api.md
+++ b/docs/src/modelling/functional-api.md
@@ -1,4 +1,267 @@
 # [Functional API](@id modelling-functional-api)
 
-!!! warning "Under construction"
-    This page is being written. See the [specification reports](https://github.com/control-toolbox/OptimalControl.jl/tree/main/docs/reports).
+```@meta
+Draft = false
+```
+
+The [`@def`](@ref) macro provides a concise DSL to define optimal control problems. An alternative is the **functional API**, which builds the same problem step by step using plain Julia functions.
+
+The functional API uses `OptimalControl.PreModel` as a mutable builder, populated by setter calls, then frozen into an immutable `OptimalControl.Model` by [`build`](@ref). Both `PreModel` and `Model` are imported, not exported — write `OptimalControl.PreModel()`.
+
+!!! note
+
+    When a problem is defined with the functional API, [`definition`](@ref)`(ocp)` returns an `EmptyDefinition` — no abstract expression is stored. This contrasts with `@def`, which records the full DSL expression for display and introspection.
+
+!!! warning "Modeler compatibility"
+
+    Problems built with the functional API can only be solved with the `:adnlp` modeler (the default). The `:exa` modeler (ExaModels, GPU-capable) requires the abstract syntax [`@def`](@ref modelling-abstract-syntax). See [Solve overview](@ref solve-overview) for modeler details.
+
+## When you want this
+
+- generating problems **programmatically** from parameters, data, or loops,
+- building **library code** that must not rely on macros,
+- interfacing with external tools that process problem structures directly.
+
+## The canvas
+
+The functional API mirrors the [Formulation](@ref modelling-formulation). The correspondence is:
+
+| Math | Functional API |
+| :--- | :--- |
+| Dynamics $f(t, x, u)$ | `dyn!` passed to [`dynamics!`](@ref) |
+| Lagrange integrand $f^0(t, x, u)$ | `lag` passed to [`objective!`](@ref) |
+| Mayer terminal cost $g(x_0, x_f)$ | `may` passed to [`objective!`](@ref) |
+| Path constraint $c(t, x, u)$ | `p!` passed to [`constraint!`](@ref CTModels.Building.constraint!)`(pre, :path; ...)` |
+| Boundary constraint $b(x_0, x_f)$ | `b!` passed to [`constraint!`](@ref CTModels.Building.constraint!)`(pre, :boundary; ...)` |
+| Extra variable $v$ | [`variable!`](@ref) (extra argument to all the callbacks above) |
+
+```julia
+using OptimalControl
+
+pre = OptimalControl.PreModel()
+
+# ─── Optional: must come before time! when using indf/ind0 ───────────────────
+variable!(pre, q)                         # q = variable dimension
+# ─────────────────────────────────────────────────────────────────────────────
+
+time!(pre; t0=..., tf=...)                # fixed times
+# or: time!(pre; t0=..., indf=i)          # free final time at variable index i
+
+state!(pre, n)                            # n = state dimension
+
+# ─── Optional: omit entirely for control-free problems ───────────────────────
+control!(pre, m)                          # m = control dimension
+# ─────────────────────────────────────────────────────────────────────────────
+
+# Dynamics — in-place, signature: dyn!(dx, t, x, u, v)
+#   dx : output vector (modified in place), length n — always a vector, even for n=1
+#   t  : current time  (scalar)
+#   x  : state         (scalar if n=1, vector of length n otherwise)
+#   u  : control       (scalar if m=1, vector of length m otherwise; `nothing` if control-free)
+#   v  : variable      (scalar if q=1, vector of length q otherwise; `nothing` if no variable)
+function dyn!(dx, t, x, u, v)
+    dx[1] = ...
+    dx[2] = ...
+end
+dynamics!(pre, dyn!)
+
+# Lagrange integrand — out-of-place, signature: lag(t, x, u, v) → scalar
+lag(t, x, u, v) = ...
+# Mayer terminal cost — out-of-place, signature: may(x0, xf, v) → scalar
+#   x0 : initial state (scalar if n=1, vector of length n otherwise)
+#   xf : final state   (scalar if n=1, vector of length n otherwise)
+may(x0, xf, v) = ...
+
+objective!(pre, :min; lagrange=lag)                   # Lagrange cost
+# or: objective!(pre, :min; mayer=may)                # Mayer cost
+# or: objective!(pre, :min; mayer=may, lagrange=lag)  # Bolza cost
+
+# ─── Optional: one call per constraint ───────────────────────────────────────
+# Two families of constraints:
+#
+# (a) Box constraints on components — :state, :control, :variable
+#     rg selects the component range i:j, with lb ≤ x[rg] ≤ ub (resp. u, v).
+constraint!(pre, :state;    rg=i:j, lb=..., ub=..., label=:name)
+constraint!(pre, :control;  rg=i:j, lb=..., ub=..., label=:name)
+constraint!(pre, :variable; rg=i:j, lb=..., ub=..., label=:name)
+#
+# (b) Non-linear constraints defined by a function — :boundary, :path
+#     The constraint reads:  lb ≤ f(...) ≤ ub  (use lb=ub for equality).
+#
+#     Boundary — in-place, signature: b!(val, x0, xf, v)   (same shape as Mayer)
+#         val : output vector (modified in place), length = length(lb) = length(ub)
+#     Path — in-place, signature: p!(val, t, x, u, v)      (same shape as dynamics)
+#         val : output vector (modified in place), length = length(lb) = length(ub)
+function b!(val, x0, xf, v)
+    val[1] = ...
+end
+constraint!(pre, :boundary; f=b!, lb=..., ub=..., label=:name)
+
+function p!(val, t, x, u, v)
+    val[1] = ...
+end
+constraint!(pre, :path; f=p!, lb=..., ub=..., label=:name)
+# ─────────────────────────────────────────────────────────────────────────────
+
+# autonomous=true  ⟺  time t does NOT appear explicitly in the dynamics,
+#                     the Lagrange integrand, nor in any :path constraint.
+# autonomous=false ⟺  at least one of them depends explicitly on t.
+time_dependence!(pre; autonomous=true)
+
+ocp = build(pre)
+```
+
+**Required:** `time!` · `state!` · `dynamics!` · `objective!` · `time_dependence!` · `build`
+
+**Optional:** `variable!` · `control!` · `constraint!` (repeatable)
+
+## A worked example: double integrator, energy minimisation
+
+The simplest case: fixed time interval, boundary constraints, autonomous dynamics, Lagrange cost. The [`@def`](@ref) abstract syntax is shown on the left and the equivalent functional API on the right. See the [example gallery](@ref examples-gallery) for more problems worked both ways, including a control-free one (see also [Problems without a control](@ref modelling-without-control)).
+
+```@example ex-energy
+using OptimalControl
+using NLPModelsIpopt
+t0 = 0.0; tf = 1.0; x0 = [-1.0, 0.0]; xf = [0.0, 0.0]
+nothing # hide
+```
+
+```@raw html
+<div class="responsive-columns-40-60">
+<div>
+```
+
+**Abstract syntax**
+
+```@example ex-energy
+ocp_macro = @def begin
+
+t ∈ [t0, tf], time
+x = (q, v) ∈ R², state
+u ∈ R, control
+
+x(t0) == x0
+x(tf) == xf
+
+ẋ(t) == [v(t), u(t)]
+
+0.5∫( u(t)^2 ) → min
+
+end
+nothing # hide
+```
+
+```@raw html
+</div>
+<div>
+```
+
+**Functional API**
+
+```@example ex-energy
+pre = OptimalControl.PreModel()
+
+time!(pre; t0=t0, tf=tf)
+# state "x" with components "q" (position) and "v" (velocity)
+state!(pre, 2, "x", ["q", "v"])
+control!(pre, 1)
+
+function f_energy!(dx, t, x, u, v)
+    dx[1] = x[2]
+    dx[2] = u
+    return nothing
+end
+dynamics!(pre, f_energy!)
+
+function boundary_energy!(b, x0_, xf_, v)
+    b[1] = x0_[1] - x0[1]
+    b[2] = x0_[2] - x0[2]
+    b[3] = xf_[1] - xf[1]
+    b[4] = xf_[2] - xf[2]
+    return nothing
+end
+constraint!(pre,
+    :boundary;
+    f=boundary_energy!,
+    lb=zeros(4), ub=zeros(4),
+    label=:endpoint
+)
+
+lagrange_energy(t, x, u, v) = 0.5 * u^2
+objective!(pre, :min; lagrange=lagrange_energy)
+
+time_dependence!(pre; autonomous=true)
+
+ocp_func = build(pre)
+nothing # hide
+```
+
+```@raw html
+</div>
+</div>
+```
+
+Both formulations produce identical solutions. We solve both and plot them together for verification:
+
+```@example ex-energy
+sol_macro = solve(ocp_macro; display=false)
+sol_func = solve(ocp_func; display=false)
+
+println("Macro: objective = ", objective(sol_macro), ", iterations = ", iterations(sol_macro))
+println("Functional API: objective = ", objective(sol_func), ", iterations = ", iterations(sol_func))
+```
+
+```@example ex-energy
+plt = plot(sol_macro, :state, :control; label="Macro", color=1, size=(800, 600))
+plot!(plt, sol_func, :state, :control; label="Functional API", color=2, linestyle=:dash)
+```
+
+The two models are functionally equivalent. The key difference is visible via [`definition`](@ref): the macro records the full DSL expression, whereas the functional API stores an empty definition.
+
+```@example ex-energy
+definition(ocp_macro)
+```
+
+```@example ex-energy
+has_abstract_definition(ocp_func)
+```
+
+## [Shapes in callbacks](@id modelling-functional-api-shapes)
+
+The control above is declared with `control!(pre, 1)` — dimension 1 — and inside the callbacks `f_energy!` and `lagrange_energy` it is used as a bare `u`, not `u[1]`. This is not a special case: **1-D state, control and variable components arrive as scalars in every functional-API callback** (`dynamics!`, `objective!`, `constraint!`), exactly as on a solution and exactly as the `@def` convention (see the note on [Control](@ref modelling-abstract-syntax-control)). There is no asymmetry between "inside a callback" and "on a solution" — a dimension-1 quantity is a `Real` everywhere:
+
+```@example ex-energy
+u_macro = control(sol_macro)
+u_func  = control(sol_func)
+u_macro(t0), u_func(t0)
+```
+
+```@example ex-energy
+typeof(u_macro(t0)), typeof(u_func(t0))
+```
+
+The **in-place output buffer is the one exception**: `dx` (dynamics), `val` (boundary/path constraints) is always a vector of its declared length, written by index, even when that length is 1 — a scalar cannot be mutated in place:
+
+```julia
+f!(r, t, x, u, v) = (r[1] = -x + u; nothing)  # r is always a vector; x, u here are scalars
+```
+
+This is the one place on the site where this is spelled out; every other page just follows it.
+
+## Order and preconditions
+
+- `variable!` → before `time!` when using free-time indices (`indf`, `ind0`)
+- `variable!` → before `dynamics!` and `objective!`
+- `dynamics!` and `objective!` → after `time!` and `state!`
+- `control!` is optional and, when used, has no ordering constraint of its own beyond needing `state!` first (component-count validation) — see [Problems without a control](@ref modelling-without-control) for what omitting it means.
+
+## Equivalence
+
+The abstract and functional forms are not just "meant to agree" — it's a tested contract. `test/suite/problems/test_forms_equivalent.jl` builds both forms for every problem in the shared test library and asserts they agree on dimensions, traits (`is_autonomous`, `is_variable`, `is_control_free`), time-horizon status, cost, dynamics, and constraint-dimension accessors. The one deliberate difference the test itself asserts: `has_abstract_definition` is `true` only for the `@def` form, as shown above.
+
+## See also
+
+- [Formulation](@ref modelling-formulation) — the mathematics this API builds.
+- [Abstract syntax (`@def`)](@ref modelling-abstract-syntax) — the macro alternative.
+- [Problems without a control](@ref modelling-without-control) — omitting `control!` entirely.
+- [Inspect a problem](@ref modelling-inspect) — read a built model back.

--- a/docs/src/modelling/inspect.md
+++ b/docs/src/modelling/inspect.md
@@ -1,4 +1,637 @@
 # [Inspect a problem](@id modelling-inspect)
 
-!!! warning "Under construction"
-    This page is being written. See the [specification reports](https://github.com/control-toolbox/OptimalControl.jl/tree/main/docs/reports).
+```@meta
+Draft = false
+```
+
+Once a problem is built — via [`@def`](@ref) or the [functional API](@ref modelling-functional-api) — every part of it can be read back: dimensions, names, dynamics, costs, constraints, traits. This page is about reading a model, not solving it: for that, see [Solve overview](@ref solve-overview); for the indirect/PMP route, see [Flows overview](@ref flows-overview).
+
+```@example main
+using OptimalControl
+nothing # hide
+```
+
+A model prints as a readable summary:
+
+```@example main
+ocp = @def begin
+    t ∈ [0, 1], time
+    x = (q, v) ∈ R², state
+    u ∈ R, control
+    x(0) == [-1, 0]
+    x(1) == [0, 0]
+    ẋ(t)  == [v(t), u(t)]
+    0.5∫( u(t)^2 ) → min
+end
+ocp
+```
+
+To illustrate the accessors in the sections below, we use a richer problem: free final time, a variable, and several kinds of constraints.
+
+```@example main
+ocp = @def begin
+    v = (w, tf) ∈ R²,   variable
+    s ∈ [0, tf],        time
+    q = (x, y) ∈ R²,    state
+    u ∈ R,              control
+    0 ≤ tf ≤ 2,         (1)
+    u(s) ≥ 0,           (cons_u)
+    x(s) + u(s) ≤ 10,   (cons_mixed)
+    w == 0
+    x(0) == -1
+    y(0) - tf == 0,     (cons_bound)
+    q(tf) == [0, 0]
+    q̇(s) == [y(s)+w, u(s)]
+    0.5∫( u(s)^2 ) → min
+end
+nothing # hide
+```
+
+## Times
+
+The time component defines the temporal domain of the optimal control problem.
+
+### Times model
+
+Get the times model:
+
+```@example main
+times(ocp)  # returns the TimesModel struct containing time information
+```
+
+You can also access initial and final times separately:
+
+```@example main
+initial_time(ocp)  # returns the initial time value
+```
+
+For the final time, if it is free (part of the variable), you need to provide the variable value:
+
+```@example main
+v = [1, 2]  # example variable values: w=1, tf=2
+final_time(ocp, v)  # returns tf value from variable
+```
+
+If you try to get the final time without providing the variable when it's free, an error occurs:
+
+```@repl main
+final_time(ocp)  # error: tf is free, need variable
+```
+
+### Time variable names
+
+Get the names of the time variable and time bounds:
+
+```@example main
+time_name(ocp)  # returns "s" (the time variable name in this OCP)
+```
+
+```@example main
+initial_time_name(ocp)  # returns "0" (initial time is fixed at 0)
+```
+
+```@example main
+final_time_name(ocp)  # returns "tf" (final time is a variable)
+```
+
+### Time fixedness predicates
+
+Check whether initial or final times are fixed or free:
+
+```@example main
+has_fixed_initial_time(ocp)  # true if t0 is fixed
+```
+
+```@example main
+has_free_initial_time(ocp)  # true if t0 is free (part of variable)
+```
+
+!!! note "Variant methods"
+    Alternative methods with `is_*` prefix are also available and equivalent:
+    - `is_initial_time_fixed(ocp)` ≡ `has_fixed_initial_time(ocp)`
+    - `is_initial_time_free(ocp)` ≡ `has_free_initial_time(ocp)`
+    - `is_final_time_fixed(ocp)` ≡ `has_fixed_final_time(ocp)`
+    - `is_final_time_free(ocp)` ≡ `has_free_final_time(ocp)`
+
+Similarly for final time:
+
+```@example main
+has_fixed_final_time(ocp)  # false (tf is free in this OCP)
+```
+
+```@example main
+has_free_final_time(ocp)  # true (tf is part of variable v)
+```
+
+### Autonomy
+
+Check if the dynamics and Lagrange cost are autonomous (time-independent):
+
+```@example main
+is_autonomous(ocp)  # false if dynamics or cost depend on time
+```
+
+For more details on autonomy, see the [Time dependence](@ref modelling-inspect-time-dependence) section below.
+
+### [Summary table](@id modelling-inspect-summary-time)
+
+| Method | Returns | Description |
+| -------- | --------- | --------- |
+| `times(ocp)` | `(Float64, Any)` | Time interval (t0, tf) or (t0, tf_name) |
+| `initial_time(ocp)` | `Float64` | Initial time t0 |
+| `final_time(ocp)` | `Float64` | Final time tf (error if free) |
+| `final_time(ocp, v)` | `Float64` | Final time tf from variable v |
+| `time_name(ocp)` | `String` | Time variable name |
+| `initial_time_name(ocp)` | `String` | Initial time name or value |
+| `final_time_name(ocp)` | `String` | Final time name or value |
+| `has_fixed_initial_time(ocp)` | `Bool` | True if t0 is fixed |
+| `has_free_initial_time(ocp)` | `Bool` | True if t0 is free |
+| `has_fixed_final_time(ocp)` | `Bool` | True if tf is fixed |
+| `has_free_final_time(ocp)` | `Bool` | True if tf is free |
+| `is_autonomous(ocp)` | `Bool` | True if time-independent |
+
+## State
+
+The state component represents the state variables of the optimal control problem.
+
+### State component information
+
+Get the name, dimension, and component names of the state:
+
+```@example main
+state_name(ocp)  # returns "q" (the state variable name)
+```
+
+```@example main
+state_dimension(ocp)  # returns 2 (dimension of state)
+```
+
+```@example main
+state_components(ocp)  # returns ["x", "y"] (component names)
+```
+
+!!! note
+
+    The component names are used when plotting the solution. See [Plot](@ref results-plot).
+
+### State box constraints
+
+Get the box constraints on the state (lower and upper bounds):
+
+```@example main
+state_constraints_box(ocp)  # returns box constraints if any
+```
+
+!!! note "Tuple structure"
+    The returned tuple has the structure `(lb, indices, ub, labels, aliases)` where:
+    - `lb`: vector of lower bounds
+    - `indices`: vector of component indices (1-based)
+    - `ub`: vector of upper bounds
+    - `labels`: vector of constraint labels
+    - `aliases`: vector of vectors containing all labels that declared each component
+
+Get the dimension of state box constraints:
+
+```@example main
+dim_state_constraints_box(ocp)  # returns number of box constraints on state
+```
+
+### [Summary table](@id modelling-inspect-summary-state)
+
+| Method | Returns | Description |
+| -------- | --------- | --------- |
+| `state_name(ocp)` | `String` | State variable name |
+| `state_dimension(ocp)` | `Int` | State dimension |
+| `state_components(ocp)` | `Vector{String}` | State component names |
+| `state_constraints_box(ocp)` | Box constraints | State box constraints |
+| `dim_state_constraints_box(ocp)` | `Int` | Number of state box constraints |
+
+## Control
+
+The control component represents the control variables of the optimal control problem.
+
+### Control component information
+
+Get the name, dimension, and component names of the control:
+
+```@example main
+control_name(ocp)  # returns "u" (the control variable name)
+```
+
+```@example main
+control_dimension(ocp)  # returns 1 (dimension of control)
+```
+
+```@example main
+control_components(ocp)  # returns ["u"] (component names)
+```
+
+### Control box constraints
+
+Get the box constraints on the control:
+
+```@example main
+control_constraints_box(ocp)  # returns box constraints if any
+```
+
+!!! note "Tuple structure"
+    The returned tuple has the structure `(lb, indices, ub, labels, aliases)` where:
+    - `lb`: vector of lower bounds
+    - `indices`: vector of component indices (1-based)
+    - `ub`: vector of upper bounds
+    - `labels`: vector of constraint labels
+    - `aliases`: vector of vectors containing all labels that declared each component
+
+Get the dimension of control box constraints:
+
+```@example main
+dim_control_constraints_box(ocp)  # returns number of box constraints on control
+```
+
+### Control presence
+
+Check whether the problem has a control input:
+
+```@example main
+has_control(ocp)  # true if problem has a control input
+```
+
+!!! note "Variant method"
+
+    - `is_control_free(ocp)` ≡ `!has_control(ocp)`. See [Problems without a control](@ref modelling-without-control).
+
+### [Summary table](@id modelling-inspect-summary-control)
+
+| Method | Returns | Description |
+| -------- | --------- | --------- |
+| `control_name(ocp)` | `String` | Control variable name |
+| `control_dimension(ocp)` | `Int` | Control dimension |
+| `control_components(ocp)` | `Vector{String}` | Control component names |
+| `control_constraints_box(ocp)` | Box constraints | Control box constraints |
+| `dim_control_constraints_box(ocp)` | `Int` | Number of control box constraints |
+| `has_control(ocp)` | `Bool` | True if problem has a control input |
+| `is_control_free(ocp)` | `Bool` | True if problem has no control (`≡ !has_control`) |
+
+## Variable
+
+The variable component represents the optimization variables (parameters) of the optimal control problem.
+
+### Variable component information
+
+Get the name, dimension, and component names of the variable:
+
+```@example main
+variable_name(ocp)  # returns "v" (the variable name)
+```
+
+```@example main
+variable_dimension(ocp)  # returns 2 (dimension of variable)
+```
+
+```@example main
+variable_components(ocp)  # returns ["w", "tf"] (component names)
+```
+
+### Variable box constraints
+
+Get the box constraints on the variable:
+
+```@example main
+variable_constraints_box(ocp)  # returns box constraints if any
+```
+
+!!! note "Tuple structure"
+    The returned tuple has the structure `(lb, indices, ub, labels, aliases)` where:
+    - `lb`: vector of lower bounds
+    - `indices`: vector of component indices (1-based)
+    - `ub`: vector of upper bounds
+    - `labels`: vector of constraint labels
+    - `aliases`: vector of vectors containing all labels that declared each component
+
+Get the dimension of variable box constraints:
+
+```@example main
+dim_variable_constraints_box(ocp)  # returns number of box constraints on variable
+```
+
+### Variable presence
+
+Check whether the problem has optimization variables:
+
+```@example main
+has_variable(ocp)  # true if problem has optimization variables
+```
+
+!!! note "Variant methods"
+
+    - `is_variable(ocp)` ≡ `has_variable(ocp)`
+    - `is_nonvariable(ocp)` ≡ `!has_variable(ocp)`
+
+### [Summary table](@id modelling-inspect-summary-variable)
+
+| Method | Returns | Description |
+| -------- | --------- | --------- |
+| `variable_name(ocp)` | `String` | Variable name |
+| `variable_dimension(ocp)` | `Int` | Variable dimension |
+| `variable_components(ocp)` | `Vector{String}` | Variable component names |
+| `variable_constraints_box(ocp)` | Box constraints | Variable box constraints |
+| `dim_variable_constraints_box(ocp)` | `Int` | Number of variable box constraints |
+| `has_variable(ocp)` | `Bool` | True if problem has optimization variables |
+| `is_variable(ocp)` | `Bool` | Alias for `has_variable` |
+| `is_nonvariable(ocp)` | `Bool` | True if problem has no variables (`≡ !has_variable`) |
+
+## Dynamics
+
+The dynamics component defines the differential equations governing the state evolution.
+
+### Dynamics function
+
+The dynamics are stored as an in-place function of the form `f!(dx, t, x, u, v)`:
+
+```@example main
+f! = dynamics(ocp)
+s = 0.5  # time
+q = [0.0, 1.0]  # state
+u = 2.0  # control (scalar: control_dimension(ocp) == 1)
+v = [1.0, 2.0]  # variable
+dq = similar(q)
+f!(dq, s, q, u, v)
+dq  # returns the derivative q̇
+```
+
+The first argument `dx` is mutated upon call and contains the state derivative. The other arguments are:
+
+* `t`: time
+* `x`: state
+* `u`: control
+* `v`: variable
+
+### [Summary table](@id modelling-inspect-summary-dynamics)
+
+| Method | Returns | Description |
+| -------- | --------- | --------- |
+| `dynamics(ocp)` | `Function` | In-place dynamics function f!(dx, t, x, u, v) |
+
+## Objective
+
+The objective component defines the cost function to minimize or maximize.
+
+### Criterion
+
+The criterion indicates whether the problem is a minimization or maximization:
+
+```@example main
+criterion(ocp)  # returns :min or :max
+```
+
+### Objective form
+
+The objective function can be in Mayer form, Lagrange form, or Bolza form (combination of both):
+
+* **Mayer**: $g(x(t_0), x(t_f), v) \to \min$
+* **Lagrange**: $\int_{t_0}^{t_f} f^0(t, x(t), u(t), v)\, \mathrm{d}t \to \min$
+* **Bolza**: $g(x(t_0), x(t_f), v) + \int_{t_0}^{t_f} f^0(t, x(t), u(t), v)\, \mathrm{d}t \to \min$
+
+Check which form is present:
+
+```@example main
+has_mayer_cost(ocp)  # true if Mayer cost exists
+```
+
+```@example main
+has_lagrange_cost(ocp)  # true if Lagrange cost exists
+```
+
+!!! note "Variant methods"
+    Alternative methods are also available:
+    - `is_mayer_cost_defined(ocp)` ≡ `has_mayer_cost(ocp)`
+    - `is_lagrange_cost_defined(ocp)` ≡ `has_lagrange_cost(ocp)`
+
+### Mayer cost
+
+Get the Mayer cost function with signature `g(x0, xf, v)`:
+
+```@repl main
+g = mayer(ocp)  # error if no Mayer cost
+```
+
+### Lagrange cost
+
+Get the Lagrange cost function with signature `f⁰(t, x, u, v)`:
+
+```@example main
+f⁰ = lagrange(ocp)
+s = 0.5
+q = [0.0, 1.0]
+u = 2.0
+v = [1.0, 2.0]
+f⁰(s, q, u, v)  # returns the integrand value
+```
+
+### [Summary table](@id modelling-inspect-summary-objective)
+
+| Method | Returns | Description |
+| -------- | --------- | --------- |
+| `criterion(ocp)` | `Symbol` | `:min` or `:max` |
+| `has_mayer_cost(ocp)` | `Bool` | True if Mayer cost exists |
+| `has_lagrange_cost(ocp)` | `Bool` | True if Lagrange cost exists |
+| `mayer(ocp)` | `Function` | Mayer cost function g(x0, xf, v) |
+| `lagrange(ocp)` | `Function` | Lagrange cost function f⁰(t, x, u, v) |
+
+## Constraints
+
+The constraints component defines the constraints on the optimal control problem.
+
+### Individual constraints
+
+Retrieve a specific constraint by its label using the `constraint` function. It returns a tuple `(type, f, lb, ub)`:
+
+```@example main
+(type, f, lb, ub) = constraint(ocp, :eq1)
+println("type: ", type)
+x0 = [0, 1]
+xf = [2, 3]
+v  = [1, 4]
+println("val: ", f(x0, xf, v))
+println("lb: ", lb)
+println("ub: ", ub)
+```
+
+The function signature depends on the constraint type:
+
+* For `:boundary` and `:variable` constraints: `f(x0, xf, v)`
+* For other constraints (`:control`, `:state`, `:mixed`): `f(t, x, u, v)`
+
+Examples of different constraint types:
+
+```@example main
+(type, f, lb, ub) = constraint(ocp, :cons_bound)
+println("type: ", type)
+println("val: ", f(x0, xf, v))
+```
+
+```@example main
+(type, f, lb, ub) = constraint(ocp, :cons_u)
+println("type: ", type)
+s = 0.5
+q = [1.0, 2.0]
+u = 3.0
+println("val: ", f(s, q, u, v))
+```
+
+```@example main
+(type, f, lb, ub) = constraint(ocp, :cons_mixed)
+println("type: ", type)
+println("val: ", f(s, q, u, v))
+```
+
+### All constraints
+
+Get all constraints as a collection:
+
+```@example main
+constraints(ocp)  # returns all constraints
+```
+
+### Nonlinear constraints
+
+Get nonlinear path and boundary constraints:
+
+```@example main
+path_constraints_nl(ocp)  # returns nonlinear path constraints
+```
+
+```@example main
+boundary_constraints_nl(ocp)  # returns nonlinear boundary constraints
+```
+
+!!! note "Tuple structure"
+    The returned tuples have the structure `(lb, f!, ub, labels)` where:
+    - `lb`: vector of lower bounds
+    - `f!`: constraint function (in-place)
+    - `ub`: vector of upper bounds
+    - `labels`: vector of constraint labels
+
+    The constraint functions have the following signatures:
+    - Path constraints: `f!(val, t, x, u, v)` where `val` is mutated
+    - Boundary constraints: `f!(val, x0, xf, v)` where `val` is mutated
+
+Get the dimensions of nonlinear constraints:
+
+```@example main
+dim_path_constraints_nl(ocp)  # number of nonlinear path constraints
+```
+
+```@example main
+dim_boundary_constraints_nl(ocp)  # number of nonlinear boundary constraints
+```
+
+!!! note
+
+    To get the dual variable (or Lagrange multiplier) associated to a constraint, use the [`dual`](@ref) method on a solution — see [Solution object](@ref results-solution).
+
+### [Summary table](@id modelling-inspect-summary-constraints)
+
+| Method | Returns | Description |
+| -------- | --------- | --------- |
+| `constraint(ocp, label)` | `(Symbol, Function, Real, Real)` | Get constraint by label |
+| `constraints(ocp)` | Collection | All constraints |
+| `path_constraints_nl(ocp)` | Constraints | Nonlinear path constraints |
+| `boundary_constraints_nl(ocp)` | Constraints | Nonlinear boundary constraints |
+| `dim_path_constraints_nl(ocp)` | `Int` | Number of nonlinear path constraints |
+| `dim_boundary_constraints_nl(ocp)` | `Int` | Number of nonlinear boundary constraints |
+
+## Problem definition
+
+Get the problem definition as a string:
+
+```@example main
+definition(ocp)  # returns the OCP definition as AbstractDefinition
+```
+
+To extract the expression from the definition, use:
+
+```@example main
+expr = expression(ocp)  # returns the Expr from the definition
+nothing # hide
+```
+
+!!! note
+
+    The definition is optional and can be `EmptyDefinition` — this is what the [functional API](@ref modelling-functional-api) produces. Use `has_abstract_definition(ocp)` to check if a definition is present.
+
+### Definition presence
+
+Check whether the problem carries an abstract definition:
+
+```@example main
+has_abstract_definition(ocp)  # true if definition is present (not EmptyDefinition)
+```
+
+!!! note "Variant method"
+
+    - `is_abstractly_defined(ocp)` ≡ `has_abstract_definition(ocp)`
+
+## [Time dependence](@id modelling-inspect-time-dependence)
+
+Optimal control problems can be **autonomous** or **non-autonomous**. In an autonomous problem, neither the dynamics nor the Lagrange cost explicitly depends on the time variable.
+
+The following problem is autonomous.
+
+```@example main
+ocp = @def begin
+    t ∈ [ 0, 1 ], time
+    x ∈ R, state
+    u ∈ R, control
+    ẋ(t)  == u(t)                       # no explicit dependence on t
+    x(1) + 0.5∫( u(t)^2 ) → min         # no explicit dependence on t
+end
+is_autonomous(ocp)
+```
+
+The following problem is non-autonomous since the dynamics depends on `t`.
+
+```@example main
+ocp = @def begin
+    t ∈ [ 0, 1 ], time
+    x ∈ R, state
+    u ∈ R, control
+    ẋ(t)  == u(t) + t                   # explicit dependence on t
+    x(1) + 0.5∫( u(t)^2 ) → min
+end
+is_autonomous(ocp)
+```
+
+Finally, this last problem is non-autonomous because the Lagrange part of the cost depends on `t`.
+
+```@example main
+ocp = @def begin
+    t ∈ [ 0, 1 ], time
+    x ∈ R, state
+    u ∈ R, control
+    ẋ(t)  == u(t)
+    x(1) + 0.5∫( t + u(t)^2 ) → min     # explicit dependence on t
+end
+is_autonomous(ocp)
+```
+
+The variant predicate `is_nonautonomous` is also available and returns the opposite of `is_autonomous`:
+
+```@example main
+is_nonautonomous(ocp)  # true if dynamics or cost depend on time
+```
+
+!!! note "Variant method"
+
+    - `is_nonautonomous(ocp)` ≡ `!is_autonomous(ocp)`
+
+## API trap: `time` is gone
+
+`time(ocp)` is not the time accessor — `time` is `Base.time` (wall-clock time), extended but not exported. The accessor is `times(ocp)`, shown above. Calling `time(ocp)` throws a migration error pointing here — see [Migrating to v2.1](@ref migration).
+
+## See also
+
+- [Formulation](@ref modelling-formulation) — the mathematics behind these fields.
+- [Abstract syntax (`@def`)](@ref modelling-abstract-syntax) · [Functional API](@ref modelling-functional-api) — building the model this page reads.
+- [Solve overview](@ref solve-overview) — solving it.
+- [Solution object](@ref results-solution) — the symmetric page for reading back a *solution* rather than a *problem*.

--- a/docs/src/modelling/with-ai.md
+++ b/docs/src/modelling/with-ai.md
@@ -1,4 +1,211 @@
 # [With AI](@id modelling-with-ai)
 
-!!! warning "Under construction"
-    This page is being written. See the [specification reports](https://github.com/control-toolbox/OptimalControl.jl/tree/main/docs/reports).
+```@meta
+Draft = false
+```
+
+Using now common models from AI, it is an elementary task to have such an agent learn the syntax of OptimalControl.jl DSL, then use the agent to translate standard math into this DSL. Here is a typical prompt, pointing to the [abstract syntax](@ref modelling-abstract-syntax):
+
+```text
+Learn the syntax of OptimalControl.jl DSL described at the link below 
+to translate math into this DSL (Julia language): 
+https://control-toolbox.org/OptimalControl.jl/stable/modelling/abstract-syntax.
+```
+
+```@raw html
+<div style="display:flex; align-items:center; gap:8px; margin:16px 0;">
+  <span style="font-weight:600; color:#666;">Try with:</span>
+  <!-- ChatGPT -->
+  <a href="https://chat.openai.com/?q=Learn+the+syntax+of+OptimalControl.jl+DSL+described+at+the+link+below+to+translate+math+into+this+DSL+(Julia+language):+https://control-toolbox.org/OptimalControl.jl/stable/modelling/abstract-syntax" target="_blank" rel="nofollow noreferrer noopener" style="padding:4px 10px; background-color:#10A37F; color:#fff; border-radius:20px; font-size:13px; font-weight:600; text-decoration:none; transition:opacity 0.3s;">
+    ChatGPT
+  </a>
+
+  <!-- Claude -->
+  <a href="https://claude.ai/new?q=Learn+the+syntax+of+OptimalControl.jl+DSL+described+at+the+link+below+to+translate+math+into+this+DSL+(Julia+language):+https://control-toolbox.org/OptimalControl.jl/stable/modelling/abstract-syntax" target="_blank" rel="nofollow noreferrer noopener" style="padding:4px 10px; background-color:#CC9B7A; color:#fff; border-radius:20px; font-size:13px; font-weight:600; text-decoration:none; transition:opacity 0.3s;">
+    Claude
+  </a>
+
+  <!-- Perplexity -->
+  <a href="https://www.perplexity.ai/search/new?q=Learn+the+syntax+of+OptimalControl.jl+DSL+described+at+the+link+below+to+translate+math+into+this+DSL+(Julia+language):+https://control-toolbox.org/OptimalControl.jl/stable/modelling/abstract-syntax" target="_blank" rel="nofollow noreferrer noopener" style="padding:4px 10px; background-color:#9C4DE2; color:#fff; border-radius:20px; font-size:13px; font-weight:600; text-decoration:none; transition:opacity 0.3s;">
+    Perplexity
+  </a>
+
+  <!-- Mistral AI -->
+  <a href="https://chat.mistral.ai/chat?q=Learn+the+syntax+of+OptimalControl.jl+DSL+described+at+the+link+below+to+translate+math+into+this+DSL+(Julia+language):+https://control-toolbox.org/OptimalControl.jl/stable/modelling/abstract-syntax" target="_blank" rel="nofollow noreferrer noopener" style="padding:4px 10px; background-color:#FF7000; color:#fff; border-radius:20px; font-size:13px; font-weight:600; text-decoration:none; transition:opacity 0.3s;">
+    Mistral
+  </a>
+</div>
+```
+
+Now, here is an extract of, *e.g.*, [claude.ai](https://claude.ai) answer (Sonnet 4 model) to the request below:
+
+```text
+Translate the problem below into this DSL:
+
+    minimise the final time tf 
+    under the constraint q''(t) = u(t) 
+    with -1 <= u(t) <= 1, 
+    q(0) = 1, q'(0) = -2, q(tf) = 3, q'(tf) = 1, and q'(t) <= 1.
+```
+
+```julia
+@def begin
+    tf ∈ R, variable
+    t ∈ [0, tf], time
+    x = (q, v) ∈ R², state
+    u ∈ R, control
+    
+    # Variable constraint
+    tf ≥ 0
+    
+    # Control constraint
+    -1 ≤ u(t) ≤ 1
+    
+    # Initial conditions
+    q(0) == 1
+    v(0) == -2
+    
+    # Final conditions  
+    q(tf) == 3
+    v(tf) == 1
+    
+    # Path constraint
+    v(t) ≤ 1
+    
+    # Dynamics (q'' = u becomes first-order system)
+    ẋ(t) == [v(t), u(t)]
+    
+    # Objective: minimize final time
+    tf → min
+end
+```
+
+The answer is syntactically correct and can be updated, for instance according to the new request below:
+
+```text
+Use a form compatible with examodels.
+```
+
+```julia
+@def begin
+    tf ∈ R, variable
+    t ∈ [0, tf], time
+    x = (q, v) ∈ R², state
+    u ∈ R, control
+    
+    # Variable constraint
+    tf ≥ 0
+    
+    # Control constraint
+    -1 ≤ u(t) ≤ 1
+    
+    # Initial conditions
+    q(0) == 1
+    v(0) == -2
+    
+    # Final conditions  
+    q(tf) == 3
+    v(tf) == 1
+    
+    # Path constraint
+    v(t) ≤ 1
+    
+    # Dynamics (coordinate-wise for ExaModels)
+    ∂(q)(t) == v(t)
+    ∂(v)(t) == u(t)
+    
+    # Objective: minimize final time
+    tf → min
+end
+```
+
+It is also possible to feed the model directly with math definitions (here from a snapshot), as in the [example](https://control-toolbox.org/OptimalControlProblems.jl/stable/problems/rocket.html) below:
+
+```text
+translate the problem below into OptimalControl.jl DSL:
+```
+
+```@raw html
+<img src="../assets/rocket-def.png" 
+     alt="rocket-def" 
+     style="
+         display: block;
+         margin-left: 30px;
+         margin-right: 30px;
+         margin-top: 20px;
+         margin-bottom: 20px;
+         width: calc(100% - 60px);
+         height: auto;
+     ">
+
+```
+
+This prompt generates the syntactically correct code:
+
+```julia
+# Parameters
+h₀ = 1
+v₀ = 0
+m₀ = 1
+g₀ = 1
+Tc = 3.5
+hc = 500
+vc = 620
+mc = 0.6
+
+# Derived constants
+Dc = 0.5 * vc * m₀ / g₀
+mf = mc * m₀
+c = 0.5 * sqrt(g₀ * h₀)
+Tmax = Tc * m₀ * g₀
+
+# Auxiliary functions
+D(h, v) = Dc * v^2 * exp(-hc * (h - h₀) / h₀)
+g(h) = g₀ * (h₀ / h)^2
+
+rocket = @def begin
+    # Variable (free final time)
+    tf ∈ R, variable
+    
+    # Time
+    t ∈ [0, tf], time
+    
+    # State: (altitude, velocity, mass)
+    x = (h, v, m) ∈ R³, state
+    
+    # Control: thrust
+    T ∈ R, control
+    
+    # Dynamics
+    ∂(h)(t) == v(t)
+    ∂(v)(t) == (T(t) - D(h(t), v(t)) - m(t) * g(h(t))) / m(t)
+    ∂(m)(t) == -T(t) / c
+    
+    # Initial conditions
+    h(0) == h₀
+    v(0) == v₀
+    m(0) == m₀
+    
+    # Final condition
+    m(tf) == mf
+    
+    # State constraints
+    h(t) ≥ h₀
+    v(t) ≥ v₀
+    mf ≤ m(t) ≤ m₀
+    
+    # Control constraint
+    0 ≤ T(t) ≤ Tmax
+    
+    # Variable constraint
+    tf ≥ 0
+    
+    # Objective: maximize final altitude h(tf)
+    -h(tf) → min
+end
+```
+
+## See also
+
+- [Abstract syntax (`@def`)](@ref modelling-abstract-syntax) — what the AI is being taught.
+- [Example gallery](@ref examples-gallery) — more worked problems, including the rocket ascent above.

--- a/docs/src/modelling/without-control.md
+++ b/docs/src/modelling/without-control.md
@@ -1,4 +1,363 @@
 # [No control](@id modelling-without-control)
 
-!!! warning "Under construction"
-    This page is being written. See the [specification reports](https://github.com/control-toolbox/OptimalControl.jl/tree/main/docs/reports).
+```@meta
+Draft = false
+```
+
+## What this is for
+
+Control-free problems are optimal control problems without a control variable — used for **optimising constant parameters in dynamical systems**, such as:
+
+- identifying unknown parameters from observed data (parameter estimation),
+- finding optimal parameters for a given performance criterion.
+
+This page demonstrates two examples with known analytical solutions, solved both directly and indirectly.
+
+## How to declare it
+
+There is no dedicated syntax for "no control": simply never declare one. Declare a `variable`, a time, a state, dynamics, and a cost, and omit the control line entirely (on the [abstract syntax](@ref modelling-abstract-syntax)) or never call `control!` (on the [functional API](@ref modelling-functional-api)).
+
+!!! warning "`control!(pre, 0)` is an error, not a spelling for \"no control\""
+
+    A control-free problem is reached purely by omission. `control!(pre, 0)` throws
+    `IncorrectArgument` — a dimension must be positive. Internally, a `PreModel` that never
+    called `control!` keeps its default `EmptyControlModel`, and `is_control_free`/`has_control`
+    read that from the *type* of the built model's control field, not from a dimension check.
+
+```@example main-growth
+using OptimalControl
+using NLPModelsIpopt
+using Plots
+```
+
+## Worked example: exponential growth
+
+Consider a system with exponential growth:
+
+```math
+\dot{x}(t) = \lambda \cdot x(t), \quad x(0) = 2
+```
+
+where $\lambda$ is an unknown growth rate parameter. We have observed data with some perturbations and want to estimate $\lambda$ by minimising the squared error:
+
+```math
+\min_{\lambda} \int_0^{2} (x(t) - x_{\text{obs}}(t))^2 \, \mathrm{d}t
+```
+
+The underlying model has $\lambda = 0.5$, but the observed data includes perturbations.
+
+```@example main-growth
+# observed data (analytical solution with λ = 0.5)
+λ_true = 0.5
+model(t) = 2 * exp(λ_true * t)
+perturbation(t) = 2e-1*sin(4π*t)
+data(t) = model(t) + perturbation(t)
+
+# optimal control problem (parameter estimation)
+t0 = 0; tf = 2; x0 = 2
+ocp = @def begin
+    λ ∈ R, variable              # growth rate to estimate
+    t ∈ [t0, tf], time
+    x ∈ R, state
+
+    x(t0) == x0
+    ẋ(t) == λ * x(t)
+
+    ∫((x(t) - data(t))^2) → min  # fit to observed data
+end
+nothing # hide
+```
+
+### Direct method
+
+```@example main-growth
+direct_sol = solve(ocp; grid_size=20, display=false)
+```
+
+```@example main-growth
+println("Estimated growth rate: λ = ", variable(direct_sol))
+println("Objective value: ", objective(direct_sol))
+nothing # hide
+```
+
+```@example main-growth
+plt = plot(direct_sol, :state; size=(800, 400), label="Direct")
+t_grid = time_grid(direct_sol)
+plot!(plt, t_grid, data.(t_grid); subplot=1, line=:dot, lw=2, label="Data", color=:black)
+```
+
+The estimated parameter should be close to $\lambda \approx 0.5$.
+
+### Indirect method
+
+We now solve the same problem using an indirect shooting method based on Pontryagin's Maximum Principle.
+
+```@example main-growth
+using OrdinaryDiffEq  # ODE solver
+using NonlinearSolve  # Nonlinear solver
+```
+
+For control-free problems with a variable parameter, we use an **augmented Hamiltonian** approach. The Hamiltonian for this problem is:
+
+```math
+H(t, x, p, \lambda) = p \lambda x - (x - x_{\text{obs}}(t))^2
+```
+
+To handle the variable parameter $\lambda$, we treat it as an additional state with zero dynamics. This gives us the augmented system with state $(x, \lambda)$ and costate $(p, p_\lambda)$, where:
+
+```math
+\begin{aligned}
+\frac{\mathrm{d}x}{\mathrm{d}t} &= \frac{\partial H}{\partial p} = \lambda x \\
+\frac{\mathrm{d}\lambda}{\mathrm{d}t} &= 0 \quad \text{(constant parameter)} \\
+\frac{\mathrm{d}p}{\mathrm{d}t} &= -\frac{\partial H}{\partial x} = -p\lambda + 2(x - x_{\text{obs}}(t)) \\
+\frac{\mathrm{d}p_\lambda}{\mathrm{d}t} &= -\frac{\partial H}{\partial \lambda} = -px
+\end{aligned}
+```
+
+The transversality condition for the variable parameter requires $p_\lambda(t_f) - p_\lambda(t_0) = 0$. Assuming $p_\lambda(t_0) = 0$, we have to satisfy:
+
+```math
+p_\lambda(t_f) = -\int_{t_0}^{t_f} \frac{\partial H}{\partial \lambda}(t, x(t), p(t), \lambda) \, \mathrm{d}t = 0
+```
+
+We use `variable_costate=true` to automatically compute $p_\lambda(t_f)$ without manually constructing the augmented system.
+
+```@example main-growth
+# Create Hamiltonian flow from the control-free OCP
+f = Flow(ocp)
+nothing # hide
+```
+
+!!! note
+
+    For more on building flows from an OCP, see [Flows overview](@ref flows-overview) and
+    [From an OCP](@ref flows-from-ocp).
+
+The shooting function enforces the transversality conditions $p(t_f) = 0$ and $p_\lambda(t_f) = 0$. With `variable_costate=true`, the flow returns $(x(t_f), p(t_f), p_\lambda(t_f))$, with $p_\lambda(t_0) = 0$ by construction. The variable is passed as a keyword, `variable=λ`:
+
+```@example main-growth
+# Shooting function: S(p0, λ) = (p(tf), pλ(tf))
+function shoot!(s, p0, λ)
+    _, px_tf, pλ_tf = f(t0, x0, p0, tf; variable=λ, variable_costate=true)
+    s[1] = px_tf
+    s[2] = pλ_tf
+    return nothing
+end
+
+# Auxiliary in-place NLE function
+nle!(s, y, _) = shoot!(s, y...)
+nothing # hide
+```
+
+We use the direct solution to initialise the shooting method:
+
+```@example main-growth
+p_direct = costate(direct_sol)
+λ_direct = variable(direct_sol)
+
+p0_guess = p_direct(t0)
+λ_guess = λ_direct
+
+prob_indirect = NonlinearProblem(nle!, [p0_guess, λ_guess])
+shooting_sol = solve(prob_indirect; show_trace=Val(false))
+p0_sol, λ_sol = shooting_sol.u
+
+println("Indirect solution:")
+println("Initial costate: p0 = ", p0_sol)
+println("Parameter: λ = ", λ_sol)
+nothing # hide
+```
+
+Finally, we compute and plot the indirect solution — the trajectory call takes no `saveat`, it returns a full solution over the flow's own grid:
+
+```@example main-growth
+indirect_sol = f((t0, tf), x0, p0_sol; variable=λ_sol)
+plot!(plt, indirect_sol, :state; linestyle=:dash, lw=2, label="Indirect", color=2)
+```
+
+The direct and indirect solutions match closely, both fitting the perturbed observed data.
+
+## Worked example: harmonic oscillator
+
+```@setup main-harmonic
+using OptimalControl
+using NLPModelsIpopt
+using Plots
+using OrdinaryDiffEq
+using NonlinearSolve
+```
+
+Consider a harmonic oscillator:
+
+```math
+\ddot{q}(t) = -\omega^2 q(t)
+```
+
+with initial conditions $q(0) = 1$, $\dot{q}(0) = 0$ and final condition $q(1) = 0$. We want to find the minimal pulsation $\omega$ satisfying these constraints:
+
+```math
+    \begin{aligned}
+        & \text{Minimise} && \omega^2 \\
+        & \text{subject to} \\
+        & && \ddot{q}(t) = -\omega^2 q(t), \\[1.0em]
+        & && q(0) = 1, \quad \dot{q}(0) = 0, \\[0.5em]
+        & && q(1) = 0.
+    \end{aligned}
+```
+
+The analytical solution is $\omega = \pi/2 \approx 1.5708$, giving $q(t) = \cos(\pi t / 2)$.
+
+```@example main-harmonic
+q0 = 1; v0 = 0
+t0 = 0; tf = 1
+ocp = @def begin
+    ω ∈ R, variable              # pulsation to optimize
+    t ∈ [t0, tf], time
+    x = (q, v) ∈ R², state
+
+    q(t0) == q0
+    v(t0) == v0
+    q(tf) == 0.0                  # final condition
+
+    ẋ(t) == [v(t), -ω^2 * q(t)]
+
+    ω^2 → min   # minimize pulsation
+end
+nothing # hide
+```
+
+### Direct method
+
+```@example main-harmonic
+direct_sol = solve(ocp; grid_size=20, display=false)
+```
+
+```@example main-harmonic
+println("Optimal pulsation: ω = ", variable(direct_sol))
+println("Objective value: ω² = ", objective(direct_sol))
+println("Expected: ω = π/2 ≈ 1.5708, ω² ≈ 2.4674")
+nothing # hide
+```
+
+```@example main-harmonic
+plot(direct_sol, :state; size=(800, 400))
+```
+
+### Comparison with the analytical solution
+
+```@example main-harmonic
+t_analytical = range(0, 1, 100)
+q_analytical = cos.(π * t_analytical / 2)
+v_analytical = -(π/2) * sin.(π * t_analytical / 2)
+
+plt = plot(direct_sol, :state; size=(800, 600), label="Direct")
+plot!(plt, t_analytical, q_analytical;
+      label="q (analytical)", linestyle=:dash, linewidth=2, subplot=1)
+plot!(plt, t_analytical, v_analytical;
+      label="v (analytical)", linestyle=:dash, linewidth=2, subplot=2)
+```
+
+The numerical and analytical solutions should match closely.
+
+### Indirect method
+
+For this control-free problem with a variable parameter, we again use the augmented-Hamiltonian approach. The Hamiltonian is:
+
+```math
+H(x, p, \omega) = p_1 v + p_2 (-\omega^2 q)
+```
+
+Treating $\omega$ as an additional state with zero dynamics gives the augmented system with state $(q, v, \omega)$ and costate $(p_1, p_2, p_\omega)$:
+
+```math
+\begin{aligned}
+\frac{\mathrm{d}q}{\mathrm{d}t} &= \frac{\partial H}{\partial p_1} = v \\
+\frac{\mathrm{d}v}{\mathrm{d}t} &= \frac{\partial H}{\partial p_2} = -\omega^2 q \\
+\frac{\mathrm{d}\omega}{\mathrm{d}t} &= 0 \quad \text{(constant parameter)} \\
+\frac{\mathrm{d}p_1}{\mathrm{d}t} &= -\frac{\partial H}{\partial q} = \omega^2 p_2 \\
+\frac{\mathrm{d}p_2}{\mathrm{d}t} &= -\frac{\partial H}{\partial v} = -p_1 \\
+\frac{\mathrm{d}p_\omega}{\mathrm{d}t} &= -\frac{\partial H}{\partial \omega} = 2\omega q p_2
+\end{aligned}
+```
+
+For a Mayer cost $g(\omega) = \omega^2$, the transversality condition for the variable parameter is $p_\omega(t_f) - p_\omega(t_0) = -\partial g/\partial \omega = -2\omega$; assuming $p_\omega(t_0) = 0$:
+
+```math
+p_\omega(t_f) = -\int_{t_0}^{t_f} \frac{\partial H}{\partial \omega}(t, x(t), p(t), \omega) \, \mathrm{d}t = -2\omega
+```
+
+```@example main-harmonic
+f = Flow(ocp)
+nothing # hide
+```
+
+The shooting function enforces: $q(t_f) = 0$ (final condition), $p_2(t_f) = 0$ (free final velocity), and $p_\omega(t_f) + 2\omega = 0$ (Mayer-cost transversality). With `variable_costate=true`, the flow returns $(x(t_f), p(t_f), p_\omega(t_f))$, with $p_\omega(t_0) = 0$ by construction:
+
+```@example main-harmonic
+function shoot!(s, p0, ω)
+    x_tf, p_tf, pω_tf = f(t0, [q0, v0], p0, tf; variable=ω, variable_costate=true)
+    q_tf = x_tf[1]
+    pv_tf = p_tf[2]
+    s[1] = q_tf         # q(tf) = 0
+    s[2] = pv_tf        # p2(tf) = 0 (free final velocity)
+    s[3] = pω_tf + 2ω   # pω(tf) + 2ω = 0 (Mayer cost transversality)
+    return nothing
+end
+
+nle!(s, y, _) = shoot!(s, y[1:2], y[3])
+nothing # hide
+```
+
+```@example main-harmonic
+p_direct = costate(direct_sol)
+ω_direct = variable(direct_sol)
+
+p0_guess = p_direct(t0)
+ω_guess = ω_direct
+
+prob_indirect = NonlinearProblem(nle!, [p0_guess..., ω_guess])
+shooting_sol = solve(prob_indirect; show_trace=Val(false))
+p0_sol, ω_sol = shooting_sol.u[1:2], shooting_sol.u[3]
+
+println("Indirect solution:")
+println("Initial costate: p0 = ", p0_sol)
+println("Parameter: ω = ", ω_sol)
+nothing # hide
+```
+
+```@example main-harmonic
+indirect_sol = f((t0, tf), [q0, v0], p0_sol; variable=ω_sol)
+plot!(plt, indirect_sol, :state; linestyle=:dash, lw=2, label="Indirect", color=2)
+```
+
+The direct and indirect solutions match closely, both finding the optimal pulsation $\omega \approx \pi/2$.
+
+## How the package knows
+
+`is_control_free(ocp)` and `has_control(ocp)` don't check a dimension — they read the *type*
+of the built model's control field. A `PreModel` that never called `control!` keeps its
+default `EmptyControlModel`; `build` copies that straight into the immutable `Model`, and
+`is_control_free` dispatches on that type. There is nothing to configure: reaching
+`ControlFree` is purely a consequence of never calling `control!`.
+
+## Adding a control back
+
+To turn either of these examples into a controlled problem, declare a control and give
+`Flow` a control law: `Flow(ocp, law)`. Two guards are worth knowing before you try:
+
+- `Flow(ocp)` — no law — only works on a control-free model. On a model **with** a control
+  it throws `PreconditionError("Flow from a with-control OCP is not supported")`, suggesting
+  `Flow(ocp, law)`.
+- `constraint=`/`multiplier=` on a control-free `Flow(ocp)` are rejected — `PreconditionError
+  ("constrained flows are not supported for control-free problems")` — there is no control
+  law and so no pseudo-Hamiltonian to carry a $\mu \cdot g$ term. Use
+  `Flow(ocp, law; constraint=…, multiplier=…)` instead.
+
+See the [example gallery](@ref examples-gallery) for a worked example with both.
+
+## See also
+
+- [Formulation](@ref modelling-formulation) — the control-free case, $m=0$.
+- [Abstract syntax (`@def`)](@ref modelling-abstract-syntax) — the control-free syntax.
+- [Functional API](@ref modelling-functional-api) — the control-free functional-API form.
+- [From an OCP](@ref flows-from-ocp) — building flows in general.


### PR DESCRIPTION
## Summary

- Writes the six "Modelling" pages (`docs/src/modelling/`), replacing the PR-2 stubs wholesale: `formulation.md`, `abstract-syntax.md`, `functional-api.md`, `without-control.md` (new page), `inspect.md`, `with-ai.md`.
- All content re-verified against current source (`CTModels.jl`, `CTBase`, `CTFlows.jl`, `CTParser.jl`) and live builds, not just ported from `docs/attic/` — several factual errors in the old docs were caught and fixed rather than carried forward:
  - **`functional-api.md`**: removed the "callbacks always receive vectors" claim (contradicts the tested "1-D is a scalar" contract, `test/suite/shape/test_shape_contract.jl`), fixed the indexing (`u[1]` → `u`) across the worked example, and replaced it with an explicit `## Shapes in callbacks` section stating the real rule (the in-place output buffer is the one exception). Also dropped the spec's own example count down from the attic's six to the one the `03-modelling.md` outline actually calls for, deferring the rest to the future examples gallery (PR 10).
  - **`abstract-syntax.md`**: removed a self-contradictory `!!! compat "Upcoming feature"` note claiming control-free problems aren't supported yet, immediately after two working examples showing they are — confirmed live against `CTModels.jl/src/Building/control.jl` and the test suite.
  - **`without-control.md`** (new): assembled from `docs/attic/example-control-free.md`, with the indirect-method (shooting) code fixed to the current `CTFlows.jl` call signature (`variable=`, `variable_costate=`) — the attic version used a stale `augment=true`/positional-`variable` API that no longer exists. Verified end-to-end against both real test fixtures (`ExponentialGrowth`: recovered p≈0.5; `HarmonicOscillator`: recovered ω≈π/2).
  - **`inspect.md`**: dropped the docstring-wrapper section (now covered by PR 4's generated API reference), kept and relocated the richer running example.
  - **`with-ai.md`**: fixed six stale URLs pointing at the old `manual-abstract.html` page.
  - **`formulation.md`**: moved from `index.md`, which is trimmed to a short pointer. The old `@id math-formulation` anchor is dropped rather than kept alive — Documenter only recognizes `@id` as the sole child of a heading, so a same-page dual anchor isn't achievable; no live page referenced it.
- Filed **[CTModels.jl#392](https://github.com/control-toolbox/CTModels.jl/issues/392)**: `plot(sol)` throws `IncorrectArgument("a VBox needs at least one child")` on a plain direct-solved solution whenever the default `description` (which includes `:costate`) is used with `layout=:split` — found while executing these pages for real (`Draft = false`). Worked around in-content with explicit `description` args; not fixed upstream in this PR since CTModels isn't owned by this repo.
- Also includes an unrelated small cosmetic fix: tighter `margin-top`/`margin-bottom` on the `<summary>` of `index.md`'s three collapsible sections (Version info / Package status / Complete manifest).

## Test plan

- [x] `julia --project=docs docs/make.jl` — full rebuild, from scratch, three iterations until clean: 0 undefined-binding/no-docs/duplicate-docs warnings, 0 errors, all six pages' `@example` blocks execute (`Draft = false`), 0 unresolved `@ref`s from them.
- [x] `npx vitepress build` on the Documenter output — site builds; spot-checked the `with-ai.md` provider-button URLs and the rocket-example asset path resolve in the built HTML.
- [x] Re-ran `test/problems/control_free.jl`, `test/suite/problems/test_forms_equivalent.jl`, `test/suite/shape/test_shape_contract.jl` — the three fixtures this PR's prose leans on are still green.
- [x] `typos` on all new/changed files — clean.
- [x] `docs/reports/03-modelling.md` acceptance criteria re-checked against the real build (5/6 ticked; the `@id math-formulation` criterion left unticked with the Documenter-limitation reasoning recorded inline).

Depends on #854 (merged). Follows the same PR-per-section pattern as #854/#855/#856.

🤖 Generated with [Claude Code](https://claude.com/claude-code)