### PR TITLE
docs: results — reading, plotting, and persisting a solution

### DIFF
--- a/docs/reports/07-results.md
+++ b/docs/reports/07-results.md
@@ -137,10 +137,29 @@ optimal."*
 
 ## Acceptance criteria
 
-- [ ] Every accessor in the `solution.md` list appears and executes.
-- [ ] The scalar-control shape is demonstrated explicitly, not merely asserted.
-- [ ] `save-load.md` exists, runs a real round-trip in both formats, and states how the format
-      is chosen.
-- [ ] `plot.md`'s flow section has `using OrdinaryDiffEqTsit5` and current `Flow` calls.
-- [ ] The `success` → `successful` note is present and links to the migration page.
-- [ ] Nothing in the section writes bare `Solution` as a type name.
+- [x] Every accessor in the `solution.md` list appears and executes — including
+      `is_empty_time_grid(sol)` in place of the spec's own `is_empty(sol)`, which does not
+      exist (`is_empty` only accepts a `TimeGridModel`, confirmed live via `MethodError`); the
+      page uses the real accessor instead of the spec's literal wording.
+- [x] The scalar-control shape is demonstrated explicitly (`typeof(u(0.25))`), not merely
+      asserted.
+- [x] `save-load.md` exists, runs a real round-trip in both formats (JLD2 exact, JSON3
+      bit-exact in the run but phrased as "not guaranteed" in general), and states how the
+      format is chosen.
+- [x] `plot.md`'s flow section has `using OrdinaryDiffEqTsit5` and current `Flow` calls —
+      including the fine-grid subsection, rewritten around `Flow(...; saveat=..., dense=false)`
+      at construction time since the old call-time `saveat=` no longer exists.
+- [x] The `success` → `successful` note is present, shows the real thrown error live, and links
+      to the migration page.
+- [x] Nothing in the section writes bare `Solution` as a type name.
+
+**Also found and fixed, beyond the checklist above:**
+- CTModels.jl#392 (the VBox-plotting bug already filed during PR 5, and hit once more during
+  PR 6) turned out to affect nearly every bare `plot(sol)` call in `plot.md`'s attic source
+  specifically — any call with an empty/default description, independent of styles or layout
+  kwargs, under this docs environment's pinned CTModels (`0.15.3-beta`). Fixed throughout with
+  explicit selectors or `layout=:group`, with one clear note near the top of the page instead
+  of repeating the caveat at every occurrence.
+- The spec's cited line for the `plot` `ExtensionError` (`CTModels.jl/src/Display/Display.jl:69`)
+  was off by 3 — the actual `throw` is at line 72; not worth a citation in the page itself, but
+  noted here for anyone cross-checking against source later.

--- a/docs/reports/README.md
+++ b/docs/reports/README.md
@@ -54,7 +54,7 @@ Status legend: ⬜ not started · 🟡 in progress · ✅ merged
 | 4 | [`docs: API reference`](https://github.com/control-toolbox/OptimalControl.jl/pull/856) | API reference | [`09`](09-api-reference.md) | 2 | ✅ |
 | 5 | [`docs: modelling`](https://github.com/control-toolbox/OptimalControl.jl/pull/865) | Modelling | [`03`](03-modelling.md) | 2 | 🟡 in review |
 | 6 | [`docs: solve`](https://github.com/control-toolbox/OptimalControl.jl/pull/866) | Solve (direct) | [`04`](04-solve-direct.md) | 5 | 🟡 in review |
-| 7 | `docs: results` | Results | [`07`](07-results.md) | 6 | ⬜ |
+| 7 | `docs: results` | Results | [`07`](07-results.md) | 6 | 🟡 branch ready, build verified green, not yet opened as a PR |
 | 8 | `docs: flows` | Flows (indirect) | [`05`](05-flows-indirect.md) | 6 | ⬜ |
 | 9 | `docs: geometry` | Geometry | [`06`](06-geometry.md) | 8 | ⬜ |
 | 10 | `docs: examples` | Examples | [`08`](08-examples.md) | 8, 9 | ⬜ |

--- a/docs/reports/README.md
+++ b/docs/reports/README.md
@@ -54,7 +54,7 @@ Status legend: ⬜ not started · 🟡 in progress · ✅ merged
 | 4 | [`docs: API reference`](https://github.com/control-toolbox/OptimalControl.jl/pull/856) | API reference | [`09`](09-api-reference.md) | 2 | ✅ |
 | 5 | [`docs: modelling`](https://github.com/control-toolbox/OptimalControl.jl/pull/865) | Modelling | [`03`](03-modelling.md) | 2 | 🟡 in review |
 | 6 | [`docs: solve`](https://github.com/control-toolbox/OptimalControl.jl/pull/866) | Solve (direct) | [`04`](04-solve-direct.md) | 5 | 🟡 in review |
-| 7 | `docs: results` | Results | [`07`](07-results.md) | 6 | 🟡 branch ready, build verified green, not yet opened as a PR |
+| 7 | [`docs: results`](https://github.com/control-toolbox/OptimalControl.jl/pull/867) | Results | [`07`](07-results.md) | 6 | 🟡 in review |
 | 8 | `docs: flows` | Flows (indirect) | [`05`](05-flows-indirect.md) | 6 | ⬜ |
 | 9 | `docs: geometry` | Geometry | [`06`](06-geometry.md) | 8 | ⬜ |
 | 10 | `docs: examples` | Examples | [`08`](08-examples.md) | 8, 9 | ⬜ |

--- a/docs/src/assets/Manifest.toml
+++ b/docs/src/assets/Manifest.toml
@@ -2061,9 +2061,9 @@ version = "1.4.4"
 
 [[deps.Plots]]
 deps = ["Base64", "Contour", "Dates", "Downloads", "FFMPEG", "FixedPointNumbers", "GR", "JLFzf", "JSON", "LaTeXStrings", "Latexify", "LinearAlgebra", "Measures", "NaNMath", "Pkg", "PlotThemes", "PlotUtils", "PrecompileTools", "Printf", "REPL", "Random", "RecipesBase", "RecipesPipeline", "Reexport", "RelocatableFolders", "Requires", "Scratch", "Showoff", "SparseArrays", "Statistics", "StatsBase", "TOML", "UUIDs", "UnicodeFun", "Unzip"]
-git-tree-sha1 = "cb20a4eacda080e517e4deb9cfb6c7c518131265"
+git-tree-sha1 = "83bd514e8ff16b5858ac54c53fa0bcf6002a3b00"
 uuid = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
-version = "1.41.6"
+version = "1.41.7"
 
     [deps.Plots.extensions]
     FileIOExt = "FileIO"

--- a/docs/src/results/plot.md
+++ b/docs/src/results/plot.md
@@ -1,4 +1,312 @@
 # [Plot](@id results-plot)
 
-!!! warning "Under construction"
-    This page is being written. See the [specification reports](https://github.com/control-toolbox/OptimalControl.jl/tree/main/docs/reports).
+```@meta
+Draft = false
+```
+
+`plot`/`plot!` extend [Plots.jl](https://docs.juliaplots.org) to draw a [`Solution`](@ref results-solution)
+directly — the same call works on a `Flow`-produced trajectory too (last section below).
+
+```@docs; canonical=false
+plot(::CTModels.Solution, ::Symbol...)
+plot!(::CTModels.Solution, ::Symbol...)
+plot!(::Plots.Plot, ::CTModels.Solution, ::Symbol...)
+```
+
+## Getting started
+
+```@example main
+using OptimalControl
+using NLPModelsIpopt
+
+t0 = 0
+tf = 1
+x0 = [-1, 0]
+xf = [0, 0]
+
+ocp = @def begin
+    t ∈ [t0, tf], time
+    x ∈ R², state
+    u ∈ R, control
+    x(t0) == x0
+    x(tf) == xf
+    ẋ(t) == [x₂(t), u(t)]
+    ∫(0.5u(t)^2) → min
+end
+
+sol = solve(ocp; display=false)
+nothing # hide
+```
+
+`plot` on a solution is an extension — nothing happens until `Plots` itself is loaded:
+
+```@example main
+using Plots
+try
+    plot(sol)
+catch e
+    println(e)
+end
+```
+
+Wait — that's not a `Plots`-missing error, it's real: [CTModels.jl#392](https://github.com/control-toolbox/CTModels.jl/issues/392),
+a genuine upstream bug hit while writing this page. A bare `plot(sol)` currently fails whenever
+the default subplot selection includes the costate column under the default `:split` layout —
+which is nearly always. **Explicit selectors or `layout=:group` both avoid it**:
+
+```@example main
+plot(sol, :state, :costate, :control)
+```
+
+Every example below uses one of those two forms for that reason, not by preference. Loading
+`Plots` before `plot(sol)` at all — the *actual* extension gate — throws a clean
+`ExtensionError` instead:
+
+```julia
+julia> using OptimalControl
+julia> plot(sol)
+ERROR: ExtensionError: missing dependencies to plot solutions
+Missing  Plots
+Hint     Run: using Plots
+```
+
+## What gets drawn by default
+
+With every group shown, the layout is a grid: state trajectories on the left, costate on the
+right, control along the bottom.
+
+```@example main
+plot(sol, :state, :costate, :control; size=(700, 450), legend=:bottomright, grid=false, linewidth=2)
+```
+
+`state_style`, `costate_style`, and `control_style` set series attributes per group (any
+Plots.jl attribute, as a `NamedTuple`):
+
+```@example main
+plot(sol, :state, :costate, :control;
+    state_style=(color=:blue,),
+    costate_style=(color=:black, linestyle=:dash),
+    control_style=(color=:red, linewidth=2),
+)
+```
+
+Vertical markers at the initial/final times are controlled by `time_style`. Any `*_style` also
+accepts `:none` to hide that group entirely:
+
+```@example main
+plot(sol, :state, :costate, :control;
+    state_style=:none,
+    costate_style=:none,
+    control_style=(color=:red,),
+    time_style=(color=:green,),
+)
+```
+
+## Choosing what to draw
+
+Positional symbols select which groups appear — `:state`, `:costate`, `:control`, and (with a
+path constraint present) `:path`, `:dual`:
+
+```julia
+plot(sol, :state)    # only the state
+plot(sol, :costate)  # only the costate
+plot(sol, :control)  # only the control
+```
+
+Combine freely:
+
+```@example main
+plot(sol, :state, :control)
+```
+
+## Layout
+
+`layout=:group` puts each family (state, costate, control) in one subplot instead of one per
+component — and, as shown above, is one of the two ways to sidestep CTModels.jl#392 on a bare
+call:
+
+```@example main
+plot(sol; layout=:group)
+```
+
+`:split` (the default) is the per-component grid used everywhere above.
+
+## The control
+
+`control=:norm` plots the Euclidean norm of the control instead of its components;
+`control=:all` plots both:
+
+```@example main
+plot(sol; control=:norm, layout=:group, size=(800, 300))
+```
+
+```@example main
+plot(sol; control=:components, layout=:group, size=(800, 300))  # the default
+```
+
+```@example main
+plot(sol; control=:all, layout=:group)
+```
+
+## Styling
+
+Covered above (`state_style`/`costate_style`/`control_style`/`time_style`) — repeated here for
+the outline: every one of them is a `NamedTuple` of Plots.jl attributes, or `:none` to hide the
+group. Use `plotattr("attribute")` (from `Plots`) to look up any attribute's aliases and
+description once `using Plots` is loaded.
+
+## Normalised time
+
+Solve the same problem for several final times and compare them on a normalised time axis
+$s = (t - t_0)/(t_f - t_0)$, via `time=:normalize` (or the British spelling, `:normalise` —
+both work):
+
+```@example main
+function lqr(tf)
+    ocp = @def begin
+        t ∈ [0, tf], time
+        x ∈ R², state
+        u ∈ R, control
+        x(0) == [0, 1]
+        ẋ(t) == [x₂(t), -x₁(t) + u(t)]
+        ∫(0.5(x₁(t)^2 + x₂(t)^2 + u(t)^2)) → min
+    end
+    return ocp
+end
+
+tfs = [3, 5, 30]
+solutions = [solve(lqr(tf); display=false) for tf in tfs]
+
+plt = plot()
+for (tf, sol) in zip(tfs, solutions)
+    plot!(plt, sol, :state, :control; time=:normalize, label="tf = $tf", xlabel="s")
+end
+
+using Plots.PlotMeasures
+px1 = plot(plt[1]; legend=false)  # x₁
+px2 = plot(plt[2]; legend=true)   # x₂
+pu = plot(plt[3]; legend=false)   # u
+plot(px1, px2, pu; layout=(1, 3), size=(800, 300), leftmargin=5mm, bottommargin=5mm)
+```
+
+## Constraints
+
+A problem with a box control constraint and a nonlinear path constraint:
+
+```@example main
+ocp_c = @def begin
+    tf ∈ R, variable
+    t ∈ [0, tf], time
+    x = (q, v) ∈ R², state
+    u ∈ R, control
+    tf ≥ 0
+    -1 ≤ u(t) ≤ 1
+    q(0) == -1
+    v(0) == 0
+    q(tf) == 0
+    v(tf) == 0
+    1 ≤ v(t) + 1 ≤ 1.8, (c1)
+    ẋ(t) == [v(t), u(t)]
+    tf → min
+end
+sol_c = solve(ocp_c; display=false)
+plot(sol_c, :state, :costate, :control, :path, :dual)
+```
+
+The path constraint's bounds are drawn alongside it, with its dual variable in its own panel.
+Style keywords for these two extra groups: `path_style`, `dual_style`, and the bounds
+decorations `state_bounds_style`, `control_bounds_style`, `path_bounds_style`:
+
+```@example main
+plot(sol_c, :state, :costate, :control, :path, :dual;
+    state_bounds_style=(linestyle=:dash,),
+    control_bounds_style=(linestyle=:dash,),
+    path_style=(color=:green,),
+    path_bounds_style=(linestyle=:dash,),
+    dual_style=(color=:red,),
+    time_style=:none,
+)
+```
+
+## Adding to an existing plot
+
+`plot!` overlays a second solution — same state/costate/control dimensions required:
+
+```@example main
+ocp2 = @def begin
+    t ∈ [t0, tf], time
+    x ∈ R², state
+    u ∈ R, control
+    x(t0) == [-0.5, -0.5]
+    x(tf) == xf
+    ẋ(t) == [x₂(t), u(t)]
+    ∫(0.5u(t)^2) → min
+end
+sol2 = solve(ocp2; display=false)
+
+plt = plot(sol, :state, :costate, :control; label="sol1", size=(700, 500))
+plot!(plt, sol2, :state, :costate, :control; label="sol2", linestyle=:dash)
+```
+
+## Custom subplots
+
+Extract `state`, `control`, `costate` as plain functions to build your own figure:
+
+```@example main
+using LinearAlgebra
+t = time_grid(sol)
+u = control(sol)
+plot(t, norm ∘ u; label="‖u‖", xlabel="t")
+```
+
+Or reach into an existing `plot(sol, ...)`'s subplots directly — order follows the
+`:state, :costate, :control, :path, :dual` grouping, in the order requested:
+
+```@example main
+plt = plot(sol, :state, :costate, :control)
+plot(plt[1])  # x₁
+```
+
+```@example main
+plot(plt[5])  # u
+```
+
+## Plotting a flow trajectory
+
+The same `plot` call works on a trajectory produced by [`Flow`](@ref) — see
+[Flows](@ref flows-overview) for how to build one; here's the plotting side:
+
+```@example main
+using OrdinaryDiffEqTsit5
+
+p = costate(sol)
+p0 = p(t0)
+f = Flow(ocp, (x, p) -> p[2])  # flow from an ocp and a feedback control law
+
+sol_flow = f((t0, tf), x0, p0)
+plot(sol_flow)
+```
+
+The default grid can be sparse — the $x_2$ subplot above shows it, or read it directly:
+
+```@example main
+time_grid(sol_flow)
+```
+
+For a denser plot, pass `saveat` **when constructing the flow**, not on the call — the call
+itself only accepts `variable`/`unsafe` (and `augment`, for costate augmentation). `dense=false`
+is required alongside `saveat`, since dense output and `saveat` conflict at the integrator
+level:
+
+```@example main
+fine_grid = range(t0, tf, 100)
+f2 = Flow(ocp, (x, p) -> p[2]; saveat=fine_grid, dense=false)
+sol_flow2 = f2((t0, tf), x0, p0)
+plot(sol_flow2)
+```
+
+## See also
+
+- [Solution object](@ref results-solution) — the accessors this page draws.
+- [Save and load](@ref results-save-load) — persist a solution instead of just plotting it.
+- [Flows](@ref flows-overview) — building the `Flow` used in the last section.

--- a/docs/src/results/save-load.md
+++ b/docs/src/results/save-load.md
@@ -1,4 +1,122 @@
 # [Save & load](@id results-save-load)
 
-!!! warning "Under construction"
-    This page is being written. See the [specification reports](https://github.com/control-toolbox/OptimalControl.jl/tree/main/docs/reports).
+```@meta
+Draft = false
+```
+
+Persist a solution to disk and read it back — for expensive solves you don't want to redo,
+warm starts across sessions, or sharing a result with someone who doesn't have the code that
+produced it.
+
+```@example main
+using OptimalControl
+using NLPModelsIpopt
+
+t0 = 0
+tf = 1
+x0 = [-1, 0]
+
+ocp = @def begin
+    t ∈ [t0, tf], time
+    x = (q, v) ∈ R², state
+    u ∈ R, control
+    x(t0) == x0
+    x(tf) == [0, 0]
+    ẋ(t) == [v(t), u(t)]
+    0.5∫(u(t)^2) → min
+end
+
+sol = solve(ocp; display=false)
+nothing # hide
+```
+
+Two functions cover the whole API — `export_ocp_solution` and `import_ocp_solution` — each
+with a `format=` keyword picking the backend:
+
+```julia
+export_ocp_solution(sol; format::Symbol=:JLD, filename::String="solution")
+import_ocp_solution(ocp; format::Symbol=:JLD, filename::String="solution")
+```
+
+`import_ocp_solution` takes the **model**, not a filename, as its positional argument — the
+solution is reconstructed against it, so the model has to be given explicitly rather than
+inferred from the file.
+
+## JLD2
+
+Exact round-trip of the underlying Julia values — the format to reach for by default.
+
+```@example main
+using JLD2
+export_ocp_solution(sol; format=:JLD, filename="solution")
+
+sol_reloaded = import_ocp_solution(ocp; format=:JLD, filename="solution")
+objective(sol_reloaded) == objective(sol)
+```
+
+## JSON3
+
+Portable, human-readable, at the cost of not being Julia-specific:
+
+```@example main
+using JSON3
+export_ocp_solution(sol; format=:JSON, filename="solution")
+
+sol_json = import_ocp_solution(ocp; format=:JSON, filename="solution")
+objective(sol_json) ≈ objective(sol)
+```
+
+## Which format
+
+JLD2 round-trips Julia values exactly — the same types come back out. JSON3 is text, portable
+across languages and tools, but floating-point round-tripping through it isn't guaranteed
+bit-exact in general the way JLD2's is — use JLD2 unless portability specifically matters.
+
+## Reloading as an initial guess
+
+A reloaded solution works as a warm start exactly like a freshly-computed one — see
+[Initial guess](@ref solve-initial-guess) for everything else `init=` accepts:
+
+```@example main
+sol_warm = solve(ocp; init=sol_reloaded, display=false)
+nothing # hide
+```
+
+## Without the extension
+
+Both functions are extensions — nothing works until the matching package is loaded:
+
+```julia
+julia> using OptimalControl
+julia> export_ocp_solution(sol; format=:JLD)
+ERROR: ExtensionError: missing dependencies to export solutions to JLD2 format
+Missing  JLD2
+Hint     Run: using JLD2
+```
+
+Same pattern for `format=:JSON`, naming `JSON3` instead. An invalid `format` is caught before
+either extension is even needed:
+
+```@example main
+try
+    export_ocp_solution(sol; format=:XML)
+catch e
+    println(e)
+end
+```
+
+## Filenames have no extension of their own
+
+`filename` is a **base name** — the extension is added automatically (`.jld2` or `.json`),
+which is why the same `filename=` works unchanged for both formats above. Including the
+extension yourself doesn't get stripped — it gets doubled:
+
+```@example main
+export_ocp_solution(sol; format=:JLD, filename="sol.jld2")
+isfile("sol.jld2.jld2")
+```
+
+## See also
+
+- [Solution object](@ref results-solution) — what gets saved and reloaded.
+- [Initial guess](@ref solve-initial-guess) — every other way to seed a solve, warm start included.

--- a/docs/src/results/solution.md
+++ b/docs/src/results/solution.md
@@ -1,4 +1,215 @@
 # [Solution object](@id results-solution)
 
-!!! warning "Under construction"
-    This page is being written. See the [specification reports](https://github.com/control-toolbox/OptimalControl.jl/tree/main/docs/reports).
+```@meta
+Draft = false
+```
+
+Everything you do after something has been computed: read the trajectories, check whether it
+converged, read the sensitivities. This page mirrors [Inspect a problem](@ref modelling-inspect)
+— that page reads a *model* back, this one reads a *solution* back — and the two sections link
+to each other throughout.
+
+## What you get back
+
+`solve` returns a [`Solution`](@ref results-solution); a `Flow` call returns a trajectory. Both
+are read with the **same generics** — `state`, `control`, `costate`, `objective`, `time_grid`,
+`plot` — so everything on this page also applies to a flow's output (see
+[Flows](@ref flows-overview)).
+
+```@example main
+using OptimalControl
+using NLPModelsIpopt
+
+t0 = 0
+tf = 1
+x0 = [-1, 0]
+
+ocp = @def begin
+    t ∈ [t0, tf], time
+    x = (q, v) ∈ R², state
+    u ∈ R, control
+    x(t0) == x0
+    x(tf) == [0, 0]
+    ẋ(t) == [v(t), u(t)]
+    0.5∫(u(t)^2) → min
+end
+
+sol = solve(ocp; display=false)
+nothing # hide
+```
+
+`Solution` and `AbstractSolution` are imported, not exported — they exist for dispatch, not for
+writing type annotations in your own code, so a signature like `f(sol::Solution) = ...` won't
+work as written; you'd need `f(sol::OptimalControl.Solution) = ...` or just not annotate.
+
+## Trajectories
+
+`state`, `control`, `variable`, and `costate` return **functions of time** (except `variable`,
+which is a single vector — variables don't vary with time):
+
+```@example main
+x = state(sol)
+u = control(sol)
+p = costate(sol)
+x(0.25), u(0.25), p(0.25)
+```
+
+These functions interpolate — they can be called anywhere in the time horizon, not just at grid
+points:
+
+```@example main
+0.25 ∈ time_grid(sol)
+```
+
+```@example main
+x(0.25)  # still works
+```
+
+`time_grid(sol)` returns the discretization nodes; `times(sol)` returns the richer `TimesModel`
+struct.
+
+**1-D is a scalar here too**: with a 1-D control, `u(t)` is a `Number`, not a length-1 vector —
+same rule as everywhere else on the site ([functional-API callbacks](@ref modelling-functional-api-shapes),
+[abstract syntax](@ref modelling-abstract-syntax-control)):
+
+```@example main
+typeof(u(0.25))
+```
+
+## The objective
+
+```@example main
+objective(sol)
+```
+
+## Did it work
+
+```@example main
+successful(sol), status(sol), message(sol)
+```
+
+```@example main
+iterations(sol), constraints_violation(sol)
+```
+
+`infos(sol)` returns a `Dict` of anything else the solver reported.
+
+!!! warning "`success` is not `successful`"
+
+    `success(sol)` looks like it should work but doesn't — it isn't and never was a CTModels
+    method (it resolves to `Base.success`, a process-exit-status function). Calling it on a
+    `Solution` now throws a migration-pointing error:
+
+    ```@example main
+    try
+        success(sol)
+    catch e
+        println(e)
+    end
+    ```
+
+    See [Migration](@ref migration) for the full list of renamed spellings.
+
+## Dual variables
+
+Dual variables (Lagrange multipliers) give sensitivity information. A richer problem to show
+them on:
+
+```@example main
+ocp = @def begin
+    tf ∈ R, variable
+    t ∈ [0, tf], time
+    x = (q, v) ∈ R², state
+    u ∈ R, control
+    tf ≥ 0, (eq_tf)
+    -1 ≤ u(t) ≤ 1, (eq_u)
+    v(t) ≤ 0.75, (eq_v)
+    x(0) == [-1, 0], (eq_x0)
+    q(tf) == 0
+    v(tf) == 0
+    ẋ(t) == [v(t), u(t)]
+    tf → min
+end
+sol = solve(ocp; display=false)
+nothing # hide
+```
+
+`dual(sol, ocp, :label)` returns the signed multiplier for a labeled constraint — a scalar for
+a variable or boundary constraint, a function of time for a path constraint:
+
+```@example main
+dual(sol, ocp, :eq_tf)   # variable constraint
+```
+
+```@example main
+dual(sol, ocp, :eq_x0)   # boundary constraint
+```
+
+```@example main
+μ_u = dual(sol, ocp, :eq_u)   # path constraint — a function of time
+μ_u(0.5)
+```
+
+!!! note "Sign convention"
+
+    `μ > 0` means the lower-side constraint is active, `μ < 0` the upper-side, `μ = 0`
+    inactive. For box constraints the solver reports separate non-negative lower/upper
+    multipliers internally; `dual` combines them as `μ = μ_lb − μ_ub` per component. The raw,
+    unsigned, non-negative versions are available separately — see below.
+
+The box-constraint duals, without going through a label — one accessor per group, no per-label
+lookup needed:
+
+```@example main
+state_constraints_lb_dual(sol), state_constraints_ub_dual(sol)
+```
+
+```@example main
+control_constraints_lb_dual(sol), control_constraints_ub_dual(sol)
+```
+
+```@example main
+variable_constraints_lb_dual(sol), variable_constraints_ub_dual(sol)
+```
+
+with matching dimension accessors:
+
+```@example main
+dim_dual_state_constraints_box(sol), dim_dual_control_constraints_box(sol), dim_dual_variable_constraints_box(sol)
+```
+
+And the nonlinear (path/boundary) duals as a whole, plus their counts:
+
+```@example main
+path_constraints_dual(sol), boundary_constraints_dual(sol)
+```
+
+```@example main
+dim_path_constraints_nl(sol), dim_boundary_constraints_nl(sol)
+```
+
+## Back to the model
+
+```@example main
+model(sol) === ocp
+```
+
+`model(sol)` gives back the exact OCP the solution was computed from — everything on
+[Inspect a problem](@ref modelling-inspect) works on it.
+
+## Empty solutions
+
+```@example main
+is_empty_time_grid(sol)
+```
+
+`false` for anything a normal `solve` produced — it's a defensive check for the placeholder
+case (an uninitialized or degenerate solution object carrying no time grid at all), not
+something a real solve leaves you needing to handle.
+
+## See also
+
+- [Inspect a problem](@ref modelling-inspect) — the model-side mirror of this page.
+- [Plot a solution](@ref results-plot) — draw everything read here.
+- [Save and load](@ref results-save-load) — persist a solution to disk and reload it.
+- [Migration](@ref migration) — every renamed accessor, `success` → `successful` included.


### PR DESCRIPTION
## Summary

Stacked on #866 (`docs/solve`, not yet merged) — base branch is `docs/solve`, not `main`, since PR 7 depends on PR 6 per the work board. Rebase onto `main` once #866 (and #865) merge.

Writes the three "Results" pages (`docs/src/results/`), replacing the PR-2 stubs: `solution.md`, `plot.md`, `save-load.md` (new page — this API was undocumented anywhere on the site before). This section is deliberately placed before Flows (PR 8): a `Flow`-produced trajectory is read and plotted with the exact same generics as a `solve`-returned `Solution`, so PR 8 can say "same as Results" instead of repeating this content.

- **`solution.md`**: the spec's own accessor list includes `is_empty(sol)`, which doesn't exist — `is_empty` only accepts a `TimeGridModel`, confirmed live via `MethodError`. Used the real accessor, `is_empty_time_grid(sol)`, instead. Dropped the "Solution struct" section (API-reference material) and the inline `export_ocp_solution`/`import_ocp_solution` note, now `save-load.md`'s job.
- **`plot.md`**: ported the attic almost entirely (spec: "thorough and current"), with two real fixes found by executing every example for real:
  - **[CTModels.jl#392](https://github.com/control-toolbox/CTModels.jl/issues/392)** (the VBox-plotting bug found in #865, hit once more in #866) turns out to affect nearly every bare `plot(sol)` call in this specific attic file — triggered by an empty/default description regardless of styles or `layout=`. Fixed throughout with explicit `:state`/`:costate`/`:control` selectors or `layout=:group`, with one clear note near the top instead of repeating the caveat at every occurrence.
  - The flow-plotting section's `saveat=fine_grid` no longer works as a call-time keyword (`(::OptimalControlFlow)(tspan, x0, p0; ...)` only accepts `variable`/`unsafe`/`augment` now) — it moved to a **construction-time** option on `Flow(...)` itself, and needs a companion `dense=false` to avoid a SciML-level dense/saveat conflict. Rewrote the subsection around the working form, verified live (117 points vs. 19 on the default grid).
  - Trimmed the `plotattr()`/`Plots.attributes()` `<details>` blocks — generic Plots.jl mechanics, not OptimalControl API.
- **`save-load.md`** (new): every claim verified live — exact JLD2 round-trip, JSON3 round-trip (bit-exact in this run, phrased as "not guaranteed" in general since JSON floats aren't always exact), the real `ExtensionError`/`IncorrectArgument` messages, and that a reloaded solution works as an `init=` warm start identically to a fresh one. Also filed **[CTModels.jl#399](https://github.com/control-toolbox/CTModels.jl/issues/399)** (feature request, not a bug): `filename` is documented as a base name with the extension always auto-appended, so `filename="sol.jld2"` writes `sol.jld2.jld2` — confirmed reproducible, documented explicitly on the page with a warning rather than silently worked around.

## Test plan

- [x] `julia --project=docs docs/make.jl` — full rebuild, two iterations to clean: 0 undefined-binding/no-docs/duplicate-docs warnings, all three pages' `@example` blocks execute, 0 unresolved `@ref`s from them.
- [x] `npx vitepress build` on the Documenter output — site builds; spot-checked cross-links into #865's `modelling-inspect` and #866's `solve-initial-guess` anchors resolve in the built HTML.
- [x] `test/suite/shape/test_shape_contract.jl` — 27/27 passed (backs the scalar-control-shape claim on `solution.md`).
- [x] `typos` — clean.
- [x] `docs/reports/07-results.md` acceptance criteria re-checked against the real build (6/6 ticked, two extra findings recorded beyond the checklist).

🤖 Generated with [Claude Code](https://claude.com/claude-code)