### PR TITLE
docs: flows — indirect methods, simulation, and inspection

### DIFF
--- a/docs/reports/05-flows-indirect.md
+++ b/docs/reports/05-flows-indirect.md
@@ -339,15 +339,43 @@ Asking for an unavailable accessor raises `IncorrectArgument`.
 
 ## Acceptance criteria
 
-- [ ] Every page's preamble loads `OrdinaryDiffEqTsit5`.
-- [ ] All ten constructor forms of the catalogue appear, each with a runnable snippet.
-- [ ] The law/constructor compatibility table and the accessor availability table are on the
-      site, not only in this report.
-- [ ] `simulation.md` and `accessors.md` exist — neither has any predecessor.
-- [ ] The re-export decision on `hamiltonian` / `hamiltonian_vector_field` / `vector_field` /
-      `get_*_gradient` is taken, implemented or explicitly deferred, and
-      `test/suite/reexport/test_ctflows.jl` matches.
-- [ ] `OpenLoop`'s unconditional non-autonomy carries a `!!! warning`.
-- [ ] No page contains a positional variable, `augment=`, `Flow(f::Function)`,
-      `Flow(ocp,u,g,μ)`, `autonomous=`, or `OptimalControl.Hamiltonian`.
-- [ ] `unsafe=true` is explained where it matters — inside the shooting loop.
+- [x] Every page's preamble loads `OrdinaryDiffEqTsit5`.
+- [x] All ten constructor forms of the catalogue appear, each with a runnable snippet —
+      confirmed live across `from-hamiltonians.md` (6) and `from-ocp.md`/`simulation.md`
+      (the 4 OCP/law forms).
+- [x] The law/constructor compatibility table and the accessor availability table are on the
+      site (`overview.md`/`from-ocp.md` state the law table piecewise; the accessor table is
+      `accessors.md`'s own centrepiece, verified cell-by-cell, with one spec cell corrected —
+      `hamiltonian(f)` on a `HamiltonianVectorField`-built flow genuinely throws
+      `IncorrectArgument`).
+- [x] `simulation.md` and `accessors.md` exist — neither has any predecessor.
+- [x] The re-export decision on `hamiltonian` / `hamiltonian_vector_field` / `vector_field` /
+      `get_*_gradient` is taken and implemented (`src/imports/ctflows.jl`), and
+      `test/suite/reexport/test_ctflows.jl` has the matching testset (73/73 passing).
+- [x] `OpenLoop`'s unconditional non-autonomy carries a `!!! warning` (`simulation.md`) —
+      worded precisely after live verification: a zero-arg closure builds without error and
+      only fails on first call, not at construction as one might assume.
+- [x] No page contains a positional variable, `augment=`, `Flow(f::Function)`,
+      `Flow(ocp,u,g,μ)`, `autonomous=`, or `OptimalControl.Hamiltonian` **as working syntax**.
+      Three surviving matches on a grep, all deliberate: `from-hamiltonians.md` shows the
+      stale `VectorField(g; autonomous=false)` failing (the point of that section), and
+      `from-ocp.md` mentions `augment=true` once in prose, explaining it was renamed to
+      `variable_costate=true` — neither presents the old spelling as something that works.
+- [x] `unsafe=true` is explained where it matters — `shooting.md`, demonstrated with a
+      synthetic finite-time-blowup ODE since the worked double-integrator example itself is
+      too well-behaved to blow up even under a wild guess.
+
+**Also found and fixed, beyond the checklist above:**
+- A reproducible Documenter build quirk, isolated but not fully root-caused: `using
+  OptimalControl` inside Documenter's `@example` sandbox (a `baremodule`) fails to bind
+  `hamiltonian`/`hamiltonian_vector_field`/`vector_field`/the four `get_*_gradient` functions
+  specifically, while `Flow`/`control_law`/`pseudo_hamiltonian` (re-exported the exact same way
+  from the same `CTFlows.Systems` module) bind fine. Confirmed via extensive bisection that
+  real, normal usage (`using OptimalControl` in an ordinary session or module) is unaffected —
+  this is specific to the sandboxed `baremodule` Documenter's `@example`/`@repl` blocks run in.
+  Worked around with a hidden (`# hide`), redundant direct import in `accessors.md`'s setup
+  block; does not change what a reader sees or what a real user needs to do.
+- The spec's own claim that a flow without an integrator loaded fails with a bare `MethodError`
+  — corrected on `overview.md`: verified live it's actually a clean `ExtensionError`.
+- `method=:cpu`/`:gpu` corrected to be a construction-time keyword (`Flow(...; method=:gpu)`),
+  not a call-time one as the spec's `overview.md` outline could be read to imply.

--- a/docs/reports/99-api-coverage.md
+++ b/docs/reports/99-api-coverage.md
@@ -143,7 +143,7 @@ All on `solve-options` or `solve-choosing-a-method`; API theme **options**.
 | `parameter` `default_parameter` `available_parameters` | `solve-gpu` |
 | `CPU` `GPU` | `solve-gpu` |
 
-## 8. Flows — 17
+## 8. Flows — 24
 
 API theme **flows**.
 
@@ -151,21 +151,25 @@ API theme **flows**.
 | --- | --- |
 | `Flow` | `flows-from-ocp`, `flows-from-hamiltonians`, `flows-simulation` |
 | `control_law` `pseudo_hamiltonian` | `flows-accessors` |
+| `hamiltonian` `hamiltonian_vector_field` `vector_field` | `flows-accessors` |
+| `get_hamiltonian_gradient` `get_variable_gradient` `get_pseudo_hamiltonian_gradient` `get_pseudo_variable_gradient` | `flows-accessors` |
 | `MultiPhaseFlow` `MultiPhaseStateFlow` `MultiPhaseHamiltonianFlow` `AnyMultiPhaseFlow` | `flows-multi-phase` |
 | `n_phases` `get_flow` `get_flows` `get_switching_time` `get_switching_times` `get_jump` `get_jumps` | `flows-multi-phase` |
 | `SciML` `AbstractIntegrator` `AbstractIntegrationResult` | `flows-overview` |
 | `final_state` `evaluate_at` | `flows-overview` |
 
-**Pending PR 8 — 7 more rows, decided but not yet implemented.** `hamiltonian`,
-`hamiltonian_vector_field`, `vector_field`, `get_hamiltonian_gradient`,
-`get_variable_gradient`, `get_pseudo_hamiltonian_gradient`, `get_pseudo_variable_gradient`
-are exported by `CTFlows` but not re-exported here, while their siblings `control_law` and
-`pseudo_hamiltonian` are. PR 8 closes the gap
-([`05-flows-indirect.md`](05-flows-indirect.md) §`flows/accessors.md`); all seven belong on
-`flows-accessors`, API theme **flows**. `system` and `integrator` stay deliberately
+**Implemented in PR 8.** `hamiltonian`, `hamiltonian_vector_field`, `vector_field`,
+`get_hamiltonian_gradient`, `get_variable_gradient`, `get_pseudo_hamiltonian_gradient`,
+`get_pseudo_variable_gradient` were exported by `CTFlows` but not re-exported here, while
+their siblings `control_law` and `pseudo_hamiltonian` were — PR 8 closed the gap
+(`src/imports/ctflows.jl`, matching `test/suite/reexport/test_ctflows.jl`'s new "Systems
+accessors — gradients and vocabulary" testset). `system` and `integrator` stay deliberately
 unexported — qualified as `CTFlows.Flows.system(f)`.
 
-After PR 8 the exported count becomes **200**.
+`length(names(OptimalControl)) - 1` measured **203** after this change, not the **200** this
+report anticipated (193 + 7) — a 3-symbol drift accumulated somewhere between this report's
+original count and PR 8, unrelated to this PR's own +7. Not audited/reconciled here; flagging
+for whoever next touches this file's top-line count.
 
 ## 9. Geometry — 7
 
@@ -262,7 +266,7 @@ Recorded so they are decided, not forgotten.
 
 | Hole | Where it belongs | Status |
 | --- | --- | --- |
-| `hamiltonian`, `hamiltonian_vector_field`, `vector_field`, `get_*_gradient` not re-exported, while `control_law` / `pseudo_hamiltonian` are | §8 | ✅ **decided**: PR 8 re-exports the seven; `system`/`integrator` stay qualified |
+| `hamiltonian`, `hamiltonian_vector_field`, `vector_field`, `get_*_gradient` not re-exported, while `control_law` / `pseudo_hamiltonian` are | §8 | ✅ **implemented**: PR 8 re-exports the seven; `system`/`integrator` stay qualified |
 | CTModels serialization: how is the format selected? | §11 | ✅ **resolved**: `format::Symbol` = `:JLD` \| `:JSON`, plus `filename` without extension. The `*Tag` types are internal dispatch and must not appear in the docs |
 | `CTDirect.DirectShooting` exists but is in neither `methods()` nor the registry | §5 | ✅ **closed**: not functional yet — out of scope, do not mention it |
 | `SolverFailure` is exported by `CTBase.Exceptions` but imported nowhere in OptimalControl | §12 | open — PR 3: surface it or note the omission |

--- a/docs/reports/README.md
+++ b/docs/reports/README.md
@@ -55,7 +55,7 @@ Status legend: ⬜ not started · 🟡 in progress · ✅ merged
 | 5 | [`docs: modelling`](https://github.com/control-toolbox/OptimalControl.jl/pull/865) | Modelling | [`03`](03-modelling.md) | 2 | 🟡 in review |
 | 6 | [`docs: solve`](https://github.com/control-toolbox/OptimalControl.jl/pull/866) | Solve (direct) | [`04`](04-solve-direct.md) | 5 | 🟡 in review |
 | 7 | `docs: results` | Results | [`07`](07-results.md) | 6 | ⬜ |
-| 8 | `docs: flows` | Flows (indirect) | [`05`](05-flows-indirect.md) | 6 | ⬜ |
+| 8 | `docs: flows` | Flows (indirect) | [`05`](05-flows-indirect.md) | 6 | 🟡 branch ready, build verified green, not yet opened as a PR |
 | 9 | `docs: geometry` | Geometry | [`06`](06-geometry.md) | 8 | ⬜ |
 | 10 | `docs: examples` | Examples | [`08`](08-examples.md) | 8, 9 | ⬜ |
 | 11 | `docs: getting started` | Getting started + `index.md` | [`02`](02-getting-started.md) | 5–10 | ⬜ |

--- a/docs/reports/README.md
+++ b/docs/reports/README.md
@@ -55,7 +55,7 @@ Status legend: ⬜ not started · 🟡 in progress · ✅ merged
 | 5 | [`docs: modelling`](https://github.com/control-toolbox/OptimalControl.jl/pull/865) | Modelling | [`03`](03-modelling.md) | 2 | 🟡 in review |
 | 6 | [`docs: solve`](https://github.com/control-toolbox/OptimalControl.jl/pull/866) | Solve (direct) | [`04`](04-solve-direct.md) | 5 | 🟡 in review |
 | 7 | `docs: results` | Results | [`07`](07-results.md) | 6 | ⬜ |
-| 8 | `docs: flows` | Flows (indirect) | [`05`](05-flows-indirect.md) | 6 | 🟡 branch ready, build verified green, not yet opened as a PR |
+| 8 | [`docs: flows`](https://github.com/control-toolbox/OptimalControl.jl/pull/868) | Flows (indirect) | [`05`](05-flows-indirect.md) | 6 | 🟡 in review |
 | 9 | `docs: geometry` | Geometry | [`06`](06-geometry.md) | 8 | ⬜ |
 | 10 | `docs: examples` | Examples | [`08`](08-examples.md) | 8, 9 | ⬜ |
 | 11 | `docs: getting started` | Getting started + `index.md` | [`02`](02-getting-started.md) | 5–10 | ⬜ |

--- a/docs/src/assets/Manifest.toml
+++ b/docs/src/assets/Manifest.toml
@@ -2061,9 +2061,9 @@ version = "1.4.4"
 
 [[deps.Plots]]
 deps = ["Base64", "Contour", "Dates", "Downloads", "FFMPEG", "FixedPointNumbers", "GR", "JLFzf", "JSON", "LaTeXStrings", "Latexify", "LinearAlgebra", "Measures", "NaNMath", "Pkg", "PlotThemes", "PlotUtils", "PrecompileTools", "Printf", "REPL", "Random", "RecipesBase", "RecipesPipeline", "Reexport", "RelocatableFolders", "Requires", "Scratch", "Showoff", "SparseArrays", "Statistics", "StatsBase", "TOML", "UUIDs", "UnicodeFun", "Unzip"]
-git-tree-sha1 = "cb20a4eacda080e517e4deb9cfb6c7c518131265"
+git-tree-sha1 = "83bd514e8ff16b5858ac54c53fa0bcf6002a3b00"
 uuid = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
-version = "1.41.6"
+version = "1.41.7"
 
     [deps.Plots.extensions]
     FileIOExt = "FileIO"

--- a/docs/src/flows/accessors.md
+++ b/docs/src/flows/accessors.md
@@ -1,4 +1,144 @@
 # [Accessors](@id flows-accessors)
 
-!!! warning "Under construction"
-    This page is being written. See the [specification reports](https://github.com/control-toolbox/OptimalControl.jl/tree/main/docs/reports).
+```@meta
+Draft = false
+```
+
+Building a flow doesn't throw away what it was built from — a flow remembers its Hamiltonian,
+its vector field, the control law you passed in, and the underlying integrator. This page is
+the map of what you can pull back out, and from which kind of flow.
+
+```@example main
+using OptimalControl
+using OrdinaryDiffEqTsit5
+using NLPModelsIpopt
+import CTFlows.Systems: # hide
+    hamiltonian, # hide
+    hamiltonian_vector_field, # hide
+    vector_field, # hide
+    get_hamiltonian_gradient, # hide
+    get_variable_gradient, # hide
+    get_pseudo_hamiltonian_gradient, # hide
+    get_pseudo_variable_gradient # hide
+nothing # hide
+```
+
+## What a flow remembers
+
+Every flow wraps a **system** (the mathematical object — a Hamiltonian, a vector field, a
+pseudo-Hamiltonian plus a law...) and an **integrator**. The four accessors below read off the
+system; the last section reaches the integrator directly.
+
+## The Hamiltonian
+
+```@example main
+h(x, p) = 0.5 * (x^2 + p^2)
+f = Flow(Hamiltonian(h))
+H = hamiltonian(f)
+H(0.0, 1.0, 0.0, 1.0)   # H(t, x, p, v)
+```
+
+## The Hamiltonian vector field
+
+```@example main
+hamiltonian_vector_field(f)
+```
+
+Returns a [`HamiltonianVectorField`](@ref) — $(\partial_p H, -\partial_x H)$ — whether or not
+the flow was built with AD.
+
+## The pseudo-Hamiltonian and the control law
+
+Only available on flows built from a pseudo-Hamiltonian (or an OCP, which is one under the
+hood) plus a law:
+
+```@example main
+htilde(x, p, u) = p * u - 0.5 * u^2
+law_fun(x, p) = p
+f_ph = Flow(PseudoHamiltonian(htilde), DynClosedLoop(law_fun))
+
+H̃ = pseudo_hamiltonian(f_ph)
+H̃(0.0, 1.0, 0.0, 1.0, 1.0)   # H̃(t, x, p, u, v)
+```
+
+```@example main
+control_law(f_ph)(1.0, 0.5)   # the law you passed in, u(x, p)
+```
+
+## Gradients
+
+Four functions, each returning a struct-wrapped callable (not a bare function or a vector) —
+expect `(t, x, p, v)`-shaped arguments when calling what they return:
+
+```@example main
+get_hamiltonian_gradient(f_ph)
+```
+
+```@example main
+get_variable_gradient(f_ph)
+```
+
+`get_pseudo_hamiltonian_gradient(f_ph)` and `get_pseudo_variable_gradient(f_ph)` mirror the
+two above, taken on $\tilde H$ before the law is substituted in rather than on the composed $H$.
+
+## Building the Hamiltonian vector field from a Hamiltonian, without a flow
+
+`hamiltonian_vector_field` also works directly on an `AbstractHamiltonian`, no `Flow` needed:
+
+```@example main
+hamiltonian_vector_field(Hamiltonian(h))
+```
+
+## What is available on which flow
+
+Not every accessor makes sense on every flow — and the failure mode differs by *why* it
+doesn't apply, confirmed live rather than assumed uniform:
+
+| Built from | `hamiltonian` | `hamiltonian_vector_field` | `pseudo_hamiltonian` | `control_law` |
+| --- | --- | --- | --- | --- |
+| `Hamiltonian(h)` | ✅ | ✅ | ✗ `IncorrectArgument` | ✗ `IncorrectArgument` |
+| `HamiltonianVectorField(hvf)` | ✗ `IncorrectArgument` | ✅ | ✗ `MethodError` | ✗ `MethodError` |
+| `PseudoHamiltonian(h̃), law` | ✅ | ✅ | ✅ | ✅ |
+| `ocp, law` | ✅ | ✅ | ✅ | ✅ |
+| `VectorField(f)` | ✗ `MethodError` | ✗ `MethodError` (use `vector_field`) | ✗ `MethodError` | ✗ `MethodError` |
+
+`IncorrectArgument` shows up where the flow *could* answer in principle but deliberately
+doesn't have enough information (a `HamiltonianVectorField`-built flow has no scalar
+Hamiltonian to hand back, only its vector field — the error says so and suggests
+`hamiltonian_vector_field` instead). `MethodError` shows up where the accessor simply has no
+method for that system type at all — a `VectorField`-built flow was never given anything
+Hamiltonian-shaped, so none of the four Hamiltonian-side accessors apply; use
+`vector_field` instead:
+
+```@example main
+vector_field(Flow(VectorField(x -> -x)))
+```
+
+```@example main
+try
+    hamiltonian(Flow(HamiltonianVectorField((x, p) -> (p, -x))))
+catch e
+    println(e)
+end
+```
+
+## The underlying system and integrator
+
+Escape hatch, for when nothing above is specific enough — `system`/`integrator` stay
+deliberately unexported (too generic a name for a DSL surface), reach them qualified:
+
+```@example main
+CTFlows.Flows.system(f)
+```
+
+```@example main
+CTFlows.Flows.integrator(f)
+```
+
+## See also
+
+- [From an OCP](@ref flows-from-ocp) — the most common source of a flow with all four
+  accessors available.
+- [From Hamiltonians and vector fields](@ref flows-from-hamiltonians) — every constructor in
+  the table above, built and shown in full.
+- [Geometry](@ref geometry-overview) — the Lie-theoretic tools these systems are built on.

--- a/docs/src/flows/constrained-arcs.md
+++ b/docs/src/flows/constrained-arcs.md
@@ -1,4 +1,152 @@
 # [Constrained arcs](@id flows-constrained-arcs)
 
-!!! warning "Under construction"
-    This page is being written. See the [specification reports](https://github.com/control-toolbox/OptimalControl.jl/tree/main/docs/reports).
+```@meta
+Draft = false
+```
+
+A flow along a boundary arc — where a state constraint is active — needs the constraint and
+its multiplier, not just the control law.
+
+```@example main
+using OptimalControl
+using OrdinaryDiffEqTsit5
+nothing # hide
+```
+
+## The setting
+
+A state constraint active on a sub-interval turns the PMP into a three-piece story:
+unconstrained arc, boundary arc (where the constraint is tight and pins down both the control
+and the multiplier in feedback form), unconstrained arc again. The boundary arc's flow needs
+that extra structure.
+
+```@example main
+t0 = 0.0
+tf = 1.0
+x0 = [-1.0, 0.0]
+VMAX = 1.2
+
+ocp = @def begin
+    t ∈ [t0, tf], time
+    x = (q, v) ∈ R², state
+    u ∈ R, control
+    x(t0) == x0
+    v(t) + 0.0 ≤ VMAX, (vmax)
+    ẋ(t) == [v(t), u(t)]
+    0.5∫(u(t)^2) → min
+end
+nothing # hide
+```
+
+## Building the constrained flow
+
+```@example main
+g(x) = VMAX - x[2]      # ≥ 0 while the constraint holds
+μ(x, p) = p[1]           # multiplier in feedback form on the boundary
+law(x, p) = 0.0           # control on the boundary arc
+
+f_boundary = Flow(ocp, law; constraint=(x, u) -> g(x), multiplier=μ)
+xf, pf = f_boundary(t0, x0, [12.0, 6.0], tf)
+xf
+```
+
+`constraint=`/`multiplier=` must be given **as a pair** — one without the other is rejected:
+
+```@example main
+try
+    Flow(ocp, law; constraint=:vmax)
+catch e
+    println(e)
+end
+```
+
+## Three ways to give the constraint
+
+**A plain `Function`** — the form above, `(x, u) -> g(x)` paired with `multiplier=μ`.
+
+**A typed `Data.StateConstraint`** (or `ControlConstraint`/`MixedConstraint`/`PathConstraint`
+for the other shapes) — equivalent, more explicit:
+
+```@example main
+f_typed = Flow(ocp, law; constraint=StateConstraint(g), multiplier=μ)
+f_typed(t0, x0, [12.0, 6.0], tf)[1] ≈ xf
+```
+
+**A `Symbol` naming a `:path` constraint already declared in the OCP** — the standout
+capability here, not just a rename:
+
+```@example main
+f_sym = Flow(ocp, law; constraint=:vmax, multiplier=μ)
+typeof(f_sym)
+```
+
+An unknown label is rejected, not silently accepted:
+
+```@example main
+try
+    Flow(ocp, law; constraint=:nope, multiplier=μ)
+catch e
+    println(e)
+end
+```
+
+!!! warning "The `Symbol` form uses the model's own sign convention"
+
+    `constraint=:vmax` pulls the constraint straight from the OCP — `v(t) ≤ V_{max}` as
+    written there — rather than whatever hand-derived $g(x) \geq 0$ you might use in a
+    shooting function. The two are **not guaranteed to agree numerically** unless you match
+    conventions yourself; pick one style per problem and stay consistent, don't mix a
+    hand-rolled `g`/`μ` pair with the model's own label expecting them to be interchangeable.
+
+## Several constraints at once
+
+Pass matched tuples of functions (or labels) and multipliers, one per active constraint on the
+boundary arc, in place of the single values above.
+
+## Assembling the arcs
+
+A boundary arc is one phase in a larger [multi-phase flow](@ref flows-multi-phase):
+unconstrained arc, then the constrained flow from `t1` (constraint activation), then
+unconstrained again from `t2` (exit) — with a jump on the costate at each switch if the
+constraint order requires one.
+
+## Positional form is gone
+
+```@example main
+try
+    Flow(ocp, law, (x, u) -> g(x), μ)
+catch e
+    println(e)
+end
+```
+
+## Partial Hamiltonian on a constrained arc
+
+`hamiltonian_type=:partial` (see [From an OCP](@ref flows-from-ocp)) is supported here too — the
+boundary arc's law is stationary for the constrained pseudo-Hamiltonian at the optimum, same as
+the unconstrained case, so `:total` and `:partial` still agree when the law is genuinely
+optimal.
+
+## Control-free flows reject constraints
+
+```@example main
+ocp_cf = @def begin
+    t ∈ [t0, tf], time
+    x ∈ R, state
+    x(t0) == 1.0
+    ẋ(t) == -x(t)
+    ∫(x(t)^2) → min
+end
+try
+    Flow(ocp_cf; constraint=(x, u) -> 1.0, multiplier=(x, p) -> 1.0)
+catch e
+    println(e)
+end
+```
+
+## See also
+
+- [Multi-phase flows](@ref flows-multi-phase) — assembling several arcs, constrained or not,
+  into one callable flow.
+- [Writing a shooting function](@ref flows-shooting) — solving for the switching times
+  themselves rather than assuming them known.

--- a/docs/src/flows/from-hamiltonians.md
+++ b/docs/src/flows/from-hamiltonians.md
@@ -1,4 +1,156 @@
-# [From Hamiltonians](@id flows-from-hamiltonians)
+# [From Hamiltonians and vector fields](@id flows-from-hamiltonians)
 
-!!! warning "Under construction"
-    This page is being written. See the [specification reports](https://github.com/control-toolbox/OptimalControl.jl/tree/main/docs/reports).
+```@meta
+Draft = false
+```
+
+Every constructor below builds a flow **without** an OCP — the building blocks
+[From an OCP](@ref flows-from-ocp) is itself assembled from. One section per constructor.
+
+```@example main
+using OptimalControl
+using OrdinaryDiffEqTsit5
+nothing # hide
+```
+
+## From a vector field
+
+The plain ODE case, $\dot x = f(x)$ (or `f(t, x)` if non-autonomous — see below):
+
+```@example main
+f = Flow(VectorField(x -> -x))
+f(0.0, 1.0, 1.0)   # (t0, x0, tf) → x(tf), exp(-1)
+```
+
+## From a Hamiltonian
+
+$\vec H = (\partial_p H, -\partial_x H)$ is obtained by automatic differentiation:
+
+```@example main
+h(x, p) = 0.5 * (x^2 + p^2)
+fh = Flow(Hamiltonian(h))
+fh(0.0, 1.0, 0.0, 1.0)   # (t0, x0, p0, tf) → (x(tf), p(tf))
+```
+
+`Hamiltonian` defaults to the natural 2-arg autonomous form `h(x, p)`. A 3-arg
+`h(t, x, p)` silently mis-dispatches unless declared explicitly non-autonomous — see below.
+
+## From a Hamiltonian vector field
+
+Same system, but $\vec H$ given directly — no AD:
+
+```@example main
+hvf(x, p) = (p, -x)
+fhvf = Flow(HamiltonianVectorField(hvf))
+fhvf(0.0, 1.0, 0.0, 1.0)
+```
+
+## From a pseudo-Hamiltonian and a control law
+
+$\tilde H(x,p,u)$ plus a law $u^*(x,p)$ — `Flow` substitutes and differentiates through it
+(AD), same as [From an OCP](@ref flows-from-ocp)'s default `hamiltonian_type=:total`:
+
+```@example main
+htilde(x, p, u) = p * u - 0.5 * u^2
+law(x, p) = p   # the maximiser of h̃ above
+fph = Flow(PseudoHamiltonian(htilde), DynClosedLoop(law))
+fph(0.0, 1.0, 0.0, 1.0)
+```
+
+## From a pseudo-Hamiltonian vector field and a control law
+
+Same idea, vector-field form: $\tilde{\vec H}(x,p,u) = (\partial_p\tilde H, -\partial_x\tilde H)$
+given directly. No `hamiltonian_type=` here — there's no pseudo-Hamiltonian scalar to
+differentiate two different ways, so passing it is rejected:
+
+```@example main
+htildevf(x, p, u) = (u, 0.0)
+fphvf = Flow(PseudoHamiltonianVectorField(htildevf), DynClosedLoop(law))
+fphvf(0.0, 1.0, 0.0, 1.0)
+```
+
+```@example main
+try
+    Flow(PseudoHamiltonianVectorField(htildevf), DynClosedLoop(law); hamiltonian_type=:partial)
+catch e
+    println(e)
+end
+```
+
+## From a SciML problem
+
+An `ODEFunction`/`ODEProblem` from the SciML ecosystem works directly — reachable through
+`OrdinaryDiffEqTsit5` alone, nothing extra to load:
+
+```@example main
+rhs!(dx, x, p, t) = (dx[1] = -x[1]; nothing)
+f_fun = Flow(ODEFunction(rhs!))
+nothing # hide
+```
+
+SciML-backed flows are always `NonFixed` — even with no real free variable, a call needs
+`variable=nothing`:
+
+```@example main
+try
+    f_fun(0.0, [1.0], 1.0)
+catch e
+    println(e)
+end
+```
+
+```@example main
+f_fun(0.0, [1.0], 1.0; variable=nothing)
+```
+
+```@example main
+prob = ODEProblem(rhs!, [1.0], (0.0, 1.0))
+f_prob = Flow(prob)
+typeof(f_prob)
+```
+
+## Non-autonomous and variable-dependent forms
+
+`is_autonomous=` and `is_variable=` (not `autonomous=`, an old spelling that no longer
+exists) declare the extra arguments a function needs:
+
+```@example main
+g(t, x) = -t * x
+fg = Flow(VectorField(g; is_autonomous=false))
+fg(0.0, 1.0, 1.0)
+```
+
+The stale form fails two ways at once — there is no `Flow(::Function)` at all, and even fixed
+to the right type, the keyword itself changed name:
+
+```@example main
+try
+    VectorField(g; autonomous=false)
+catch e
+    println(e)
+end
+```
+
+`is_inplace=` similarly declares an in-place (mutating, `f!(dx, x)`) vs out-of-place
+(`f(x) -> dx`) function — inferred automatically in most cases, settable explicitly when it
+isn't.
+
+## Summary table
+
+| Constructor | Uses AD? | Returns |
+| --- | --- | --- |
+| `Flow(VectorField(f))` | no | `StateFlow` |
+| `Flow(Hamiltonian(h))` | yes | `HamiltonianFlow` |
+| `Flow(HamiltonianVectorField(hvf))` | no | `HamiltonianFlow` |
+| `Flow(PseudoHamiltonian(h̃), law)` | yes | `HamiltonianFlow` |
+| `Flow(PseudoHamiltonianVectorField(h̃vf), law)` | no | `HamiltonianFlow` |
+| `Flow(ODEFunction(...))` / `Flow(ODEProblem(...))` | no | `StateFlow` / `SciMLProblemFlow` |
+
+## See also
+
+- [From an OCP](@ref flows-from-ocp) — the same constructors, specialised: an OCP supplies
+  $\tilde H$ automatically, you only supply the law.
+- [What you can get back from a flow](@ref flows-accessors) — which accessor works on which of
+  the flows built here.
+- [Lift and Poisson brackets](@ref geometry-lift) — the differential-geometric layer these
+  constructors sit on top of.

--- a/docs/src/flows/from-ocp.md
+++ b/docs/src/flows/from-ocp.md
@@ -1,4 +1,233 @@
 # [From an OCP](@id flows-from-ocp)
 
-!!! warning "Under construction"
-    This page is being written. See the [specification reports](https://github.com/control-toolbox/OptimalControl.jl/tree/main/docs/reports).
+```@meta
+Draft = false
+```
+
+The main path: you've worked out the PMP's maximising control $u^*(t,x,p,v)$ by hand, and want
+the Hamiltonian flow it defines.
+
+```@example main
+using OptimalControl
+using OrdinaryDiffEqTsit5
+
+t0 = 0
+tf = 1
+x0 = [-1, 0]
+
+ocp = @def begin
+    t ∈ [t0, tf], time
+    x = (q, v) ∈ R², state
+    u ∈ R, control
+    x(t0) == x0
+    x(tf) == [0, 0]
+    ẋ(t) == [v(t), u(t)]
+    0.5∫(u(t)^2) → min
+end
+nothing # hide
+```
+
+## The idea
+
+For this problem, the pseudo-Hamiltonian is $\tilde H(x,p,u) = p_1 v + p_2 u + p^0 u^2/2$
+(with $p^0 = -1$, the normal case). The maximisation condition gives $u^*(x,p) = p_2$, since
+$\partial^2_{uu}\tilde H = p^0 < 0$.
+
+## The simplest form
+
+```@example main
+f = Flow(ocp, (x, p) -> p[2])
+p0 = [12, 6]
+xf, pf = f(t0, x0, p0, tf)
+xf
+```
+
+The costate $p_0 = [12, 6]$ above is the one the PMP predicts for this problem; the flow
+reaches the target `[0, 0]` from it.
+
+## Passing a typed law
+
+`Flow(ocp, u)` above is a convenience overload — it wraps the bare function in
+`DynClosedLoop`, the law kind that carries a costate. Writing it explicitly is equivalent and
+sometimes clearer:
+
+```@example main
+f_typed = Flow(ocp, DynClosedLoop((x, p) -> p[2]))
+f_typed(t0, x0, p0, tf)[1] ≈ xf
+```
+
+Two other law kinds exist — `ClosedLoop(x -> ...)` and `OpenLoop(t -> ...)` — but they build a
+*state* flow with no costate, appropriate for simulation rather than indirect solving; see
+[Simulating a controlled system](@ref flows-simulation).
+
+## Non-autonomous problems
+
+When the dynamics depend on $t$ explicitly, the control law does too — `u(t, x, p)`:
+
+```@example main
+t0b = 0
+tfb = π / 4
+x0b = 0
+xfb = tan(π / 4) - 2log(√2 / 2)
+
+ocp_na = @def begin
+    t ∈ [t0b, tfb], time
+    x ∈ R, state
+    u ∈ R, control
+    x(t0b) == x0b
+    x(tfb) == xfb
+    ẋ(t) == u(t) * (1 + tan(t))
+    0.5∫(u(t)^2) → min
+end
+
+fb = Flow(ocp_na, (t, x, p) -> p * (1 + tan(t)))
+xf_na, pf_na = fb(t0b, x0b, 1, tfb)
+xf_na - xfb
+```
+
+## Problems with a variable
+
+An extra optimisation variable extends the law's arity — `u(x, p, v)` (or `u(t, x, p, v)` if
+also non-autonomous):
+
+```@example main
+t0c = 0
+x0c = 0
+
+ocp_v = @def begin
+    tf ∈ R, variable
+    t ∈ [t0c, tf], time
+    x ∈ R, state
+    u ∈ R, control
+    x(t0c) == x0c
+    x(tf) == 1
+    ẋ(t) == tf * u(t)
+    tf + 0.5∫(u(t)^2) → min
+end
+
+fc = Flow(ocp_v, (x, p, v) -> v * p)
+nothing # hide
+```
+
+**`variable=` is mandatory at call time** — there is no positional slot for it any more:
+
+```@example main
+tf_val = (3 / 2)^(1 / 4)
+p0c = 2 * tf_val / 3
+xf_v, pf_v = fc(t0c, x0c, p0c, tf_val; variable=tf_val)
+xf_v
+```
+
+```@example main
+try
+    fc(t0c, x0c, p0c, tf_val)
+catch e
+    println(e)
+end
+```
+
+The mirror image is also enforced: passing `variable=` to a flow built from a `Fixed` problem
+(no `variable` in the `@def`) is rejected the same way, not silently ignored.
+
+## Free final time and the augmented costate
+
+`variable_costate=true` integrates the extra adjoint $\dot p_v = -\partial H/\partial v$
+alongside $(x,p)$ and returns a 3-tuple `(xf, pf, pvf)` instead of 2 — useful for the
+transversality condition on a free variable:
+
+```@example main
+q0 = 1
+v0 = 0
+t0d = 0
+tfd = 1
+
+ocp_aug = @def begin
+    ω ∈ R, variable
+    t ∈ [t0d, tfd], time
+    x = (q, v) ∈ R², state
+    u ∈ R, control
+    q(t0d) == q0
+    v(t0d) == v0
+    q(tfd) == 0.0
+    ẋ(t) == [v(t), -ω^2 * q(t) + u(t)]
+    ω^2 + 0.5∫(u(t)^2) → min
+end
+
+f_aug = Flow(ocp_aug, (x, p, ω) -> p[2])
+ω_val = π / 2
+p0_val = [1.0, 0.5]
+
+xf_aug, pf_aug, pω = f_aug(t0d, [q0, v0], p0_val, tfd; variable=ω_val, variable_costate=true)
+pω
+```
+
+`variable_costate=true` replaced the old `augment=true` keyword — same idea, new name.
+
+## Control-free problems
+
+`Flow(ocp)` — no law argument — works when the problem has no control at all: see
+[Problems without a control](@ref modelling-without-control) for how to declare one and what
+it means.
+
+## Total or partial Hamiltonian
+
+`hamiltonian_type=` (default `:total`) chooses how the Hamiltonian flow is built from the
+pseudo-Hamiltonian and the law:
+
+- `:total` composes a `ComposedHamiltonian` — substitutes the law into $\tilde H$ and
+  differentiates *through* it: $\dot x = \partial\tilde H/\partial p +
+  (\partial\tilde H/\partial u)(\partial u/\partial p)$.
+- `:partial` builds a `PseudoHamiltonianSystem` and takes partials of $\tilde H$ at the frozen
+  feedback value: $\dot x = \partial\tilde H/\partial p\big|_{u=u^*(x,p)}$.
+
+They agree **iff the law is stationary for $\tilde H$** ($\partial\tilde H/\partial u = 0$) —
+true of every genuine PMP-optimal law, which is why the two are easy to mistake for redundant.
+They are not. On this problem's $\tilde H = p_1 v + p_2 u - \tfrac12 u^2$, the minimiser is
+$u^*=p_2$; feed it $u = p_2 + 1$ instead — not stationary — and the two modes give different
+dynamics:
+
+```@example main
+law(x, p) = p[2] + 1.0   # not the PMP minimiser
+
+f_total = Flow(ocp, law; hamiltonian_type=:total)
+f_partial = Flow(ocp, law; hamiltonian_type=:partial)
+
+xf_total, _ = f_total(t0, x0, p0, tf)
+xf_partial, _ = f_partial(t0, x0, p0, tf)
+xf_total ≈ xf_partial
+```
+
+```@example main
+# :total reproduces the stationary law's trajectory exactly — the perturbation cancels
+xf_stationary, _ = Flow(ocp, (x, p) -> p[2])(t0, x0, p0, tf)
+xf_total ≈ xf_stationary
+```
+
+Both are correct for what they compute; picking the wrong one on a non-stationary law silently
+integrates different dynamics, no error — which is why it's worth knowing this exists rather
+than assuming the two are interchangeable.
+
+## What comes back
+
+A point call (`f(t0, x0, p0, tf)`) returns `(xf, pf)` (or `(xf, pf, pvf)` with
+`variable_costate=true`). A trajectory call — `f((t0, tf), x0, p0)` — returns a real
+[`Solution`](@ref results-solution), exactly the same type `solve` returns:
+
+```@example main
+sol = f((t0, tf), x0, p0)
+typeof(sol) <: OptimalControl.Solution
+```
+
+Everything in [Solution object](@ref results-solution) and [Plot](@ref results-plot) applies
+verbatim — `state(sol)`, `control(sol)`, `objective(sol)`, `plot(sol)`. This is specific to
+flows built **from an OCP**; a flow built without one (a bare `Hamiltonian`, a
+`ControlledVectorField`, ...) returns its own trajectory wrapper instead — see
+[Simulating a controlled system](@ref flows-simulation) for that distinction.
+
+## See also
+
+- [What you can get back from a flow](@ref flows-accessors) — the Hamiltonian, its vector
+  field, and the law you passed in, pulled back out.
+- [Writing a shooting function](@ref flows-shooting) — the payoff: turn this into a root-finding
+  problem for $p_0$.
+- [Problems without a control](@ref modelling-without-control) — the `Flow(ocp)` case in full.

--- a/docs/src/flows/multi-phase.md
+++ b/docs/src/flows/multi-phase.md
@@ -1,4 +1,137 @@
-# [Multi-phase](@id flows-multi-phase)
+# [Multi-phase flows](@id flows-multi-phase)
 
-!!! warning "Under construction"
-    This page is being written. See the [specification reports](https://github.com/control-toolbox/OptimalControl.jl/tree/main/docs/reports).
+```@meta
+Draft = false
+```
+
+Bang-bang switchings, jumps at a boundary arc's entry/exit, phase changes of any kind: a
+sequence of flows, each active on its own sub-interval, concatenated into one callable object —
+itself a flow.
+
+```@example main
+using OptimalControl
+using OrdinaryDiffEqTsit5
+nothing # hide
+```
+
+## Concatenating two flows
+
+`*` glues two flows together at a switching time — the result is itself a flow:
+
+```@example main
+f1 = Flow(VectorField(x -> 0.0))    # constant
+f2 = Flow(VectorField(x -> 1.0))    # unit slope
+
+f = f1 * (1.0, f2)                  # f1 until t=1, then f2
+typeof(f)
+```
+
+```@example main
+f(0.0, 0.0, 2.0)   # one unit of f1's zero slope, then one unit of f2's slope-1
+```
+
+## Jumps
+
+A jump inserts a discontinuity in the state at the switching time — `f1 * (t1, jump, f2)`,
+where `jump` is a plain function of the state:
+
+```@example main
+jump(x) = x + 10.0
+fj = f1 * (1.0, jump, f2)
+fj(0.0, 0.0, 2.0)   # +10 landed at t=1, then one more unit of slope
+```
+
+On a **Hamiltonian** flow, the jump can act on state and costate separately — a 4-arg form,
+`h1 * (t, jump_x, jump_p, h2)`:
+
+```@example main
+htilde(x, p, u) = p * u - 0.5 * u^2
+law(x, p) = p
+h1 = Flow(PseudoHamiltonian(htilde), DynClosedLoop(law))
+h2 = Flow(PseudoHamiltonian(htilde), DynClosedLoop(law))
+
+hj = h1 * (1.0, x -> x, p -> p, h2)   # identity jumps, written out
+typeof(hj)
+```
+
+## Jumps as callables
+
+A jump argument can be a function (as above), `nothing` for the identity (no jump at all), or
+— accepted in addition to the two — a plain `Vector` added to the state/costate directly:
+
+```@example main
+h_identity = h1 * (1.0, nothing, nothing, h2)   # nothing, nothing ≡ no jump
+h_vec = h1 * (1.0, [0.0, 0.0], h2)               # a bare vector jump also works
+nothing # hide
+```
+
+## Calling a multi-phase flow
+
+Exactly like any other flow — point form for the endpoint, trajectory form for the full path;
+`variable=` still mandatory on a `NonFixed` problem, same rule as everywhere else in this
+section.
+
+## Inspecting one
+
+```@example main
+n_phases(f)
+```
+
+```@example main
+get_switching_time(f, 1)
+```
+
+```@example main
+get_switching_times(f)
+```
+
+```@example main
+get_flow(f, 1) === f1
+```
+
+```@example main
+length(get_flows(f))
+```
+
+`get_jump(mp, i)`/`get_jumps(mp)` read back the jump functions the same way, on a flow built
+with jumps.
+
+## Worked example: bang-bang time-optimal double integrator
+
+Minimise the final time for $\ddot q = u$, $u \in [-1,1]$, from $(q,v)=(-1,0)$ to $(0,0)$. The
+optimum is $t_f = 2$, reached by one switch at $t=1$: $u=+1$ then $u=-1$.
+
+```@example main
+ocp = @def begin
+    tf ∈ R, variable
+    t ∈ [0, tf], time
+    x = (q, v) ∈ R², state
+    u ∈ R, control
+    -1 ≤ u(t) ≤ 1
+    q(0) == -1
+    v(0) == 0
+    q(tf) == 0
+    v(tf) == 0
+    ẋ(t) == [v(t), u(t)]
+    tf → min
+end
+
+f_plus = Flow(ocp, (x, p, v) -> 1.0)
+f_minus = Flow(ocp, (x, p, v) -> -1.0)
+
+t1 = 1.0
+tf = 2.0
+p0 = [1.0, 1.0]   # the PMP's predicted initial costate
+
+f_bb = f_plus * (t1, f_minus)
+xf, pf = f_bb(0.0, [-1.0, 0.0], p0, tf; variable=tf)
+xf   # ≈ [0, 0], the target
+```
+
+## See also
+
+- [Constrained arcs](@ref flows-constrained-arcs) — assembling arcs around a boundary arc
+  specifically, where the jump usually comes from a costate discontinuity.
+- [Writing a shooting function](@ref flows-shooting) — solving for the switching time(s)
+  themselves, not just assuming them known as here.
+- [From an OCP](@ref flows-from-ocp) — the single-arc case this section generalises.

--- a/docs/src/flows/overview.md
+++ b/docs/src/flows/overview.md
@@ -1,4 +1,148 @@
 # [Overview](@id flows-overview)
 
-!!! warning "Under construction"
-    This page is being written. See the [specification reports](https://github.com/control-toolbox/OptimalControl.jl/tree/main/docs/reports).
+```@meta
+Draft = false
+```
+
+`Flow` is one constructor that does three distinct jobs: **indirect optimal control** (build
+the Hamiltonian flow of the Pontryagin Maximum Principle, write a shooting function, solve it),
+**simulation** (integrate a controlled system under an open-loop or feedback control), and
+**inspection** (pull the Hamiltonian, the Hamiltonian vector field, or the control law back out
+of a flow you built). This page maps the section and recaps just enough PMP to make the rest
+make sense.
+
+## Why flows
+
+The direct methods ([Solve](@ref solve-overview)) discretize the whole problem into one large
+nonlinear program. Flows integrate instead: you supply a control law — from the PMP, from a
+feedback design, from anywhere — and get back an ODE solution. Direct methods win when you
+don't yet have a control law and want the solver to find one; flows win once you do, whether
+that law came from solving the PMP by hand, from a direct solve's costate, or from a controller
+you designed independently of any optimization.
+
+## The Pontryagin Maximum Principle, briefly
+
+For an OCP with dynamics $\dot x = f(t,x,u,v)$ and Lagrange cost $f^0$, the pseudo-Hamiltonian
+is
+
+```math
+\tilde H(t, x, p, u, v) = p \cdot f(t,x,u,v) + p^0 f^0(t,x,u,v).
+```
+
+The maximisation condition picks, at each $(t,x,p,v)$, the control that extremises
+$\tilde H$ — a **control law** $u^*(t,x,p,v)$. Substituting it back gives the true Hamiltonian
+$H(t,x,p,v) = \tilde H(t,x,p,u^*(t,x,p,v),v)$, whose Hamiltonian system
+
+```math
+\dot x = \partial H/\partial p, \qquad \dot p = -\partial H/\partial x
+```
+
+is the **Hamiltonian flow** this whole section builds and integrates. Boundary conditions on
+$(x,p)$ at $t_0$/$t_f$ (transversality) turn "integrate the flow" into "find the missing
+$p_0$" — [shooting](@ref flows-shooting).
+
+## From the PMP to a flow
+
+You supply $u^*$ — worked out by hand, or read off a `@def` problem via
+[`Flow(ocp, ...)`](@ref flows-from-ocp) — and `Flow` gives you $\exp(t\vec H)$: an object
+callable at a point (endpoint only) or over a trajectory (the full path), integrated
+numerically.
+
+## Three things this section does
+
+1. **Indirect solving** — [From an OCP](@ref flows-from-ocp),
+   [Constrained arcs](@ref flows-constrained-arcs), [Multi-phase](@ref flows-multi-phase),
+   [Shooting](@ref flows-shooting).
+2. **Simulation** — [Simulating a controlled system](@ref flows-simulation): integrate under a
+   given control, no optimization involved.
+3. **Inspection** — [What you can get back from a flow](@ref flows-accessors): the Hamiltonian,
+   its vector field, the pseudo-Hamiltonian, the control law you passed in.
+
+[From Hamiltonians and vector fields](@ref flows-from-hamiltonians) covers the lower-level
+constructors these three jobs are all built from.
+
+## Before you start
+
+Every flow needs an ODE integrator, and none is a hard dependency — load one, most commonly
+`OrdinaryDiffEqTsit5`, before building any flow:
+
+```@example main
+using OptimalControl
+using NLPModelsIpopt
+
+t0 = 0
+tf = 1
+x0 = [-1, 0]
+
+ocp = @def begin
+    t ∈ [t0, tf], time
+    x = (q, v) ∈ R², state
+    u ∈ R, control
+    x(t0) == x0
+    x(tf) == [0, 0]
+    ẋ(t) == [v(t), u(t)]
+    0.5∫(u(t)^2) → min
+end
+
+try
+    Flow(ocp, (x, p) -> p[2])
+catch e
+    println(e)
+end
+```
+
+```@example main
+using OrdinaryDiffEqTsit5
+f = Flow(ocp, (x, p) -> p[2])
+nothing # hide
+```
+
+Every page in this section opens with `using OrdinaryDiffEqTsit5` — no exceptions.
+
+## Choosing an integrator and its options
+
+`describe` covers the indirect side too, not just the direct-solve strategies from
+[Choosing a method](@ref solve-choosing-a-method): `:sciml` for the integrator family,
+`:di` for the automatic-differentiation backend that builds a Hamiltonian's vector field.
+
+```@example main
+describe(:sciml)
+```
+
+Real option names worth knowing: `alg` (the ODE algorithm, default `Tsit5()`), `reltol`/
+`abstol` (default `1e-8` each), `saveat` (explicit save times), `dense` (dense output,
+`:auto` by default — resolves to `false` for a point call, `true` for a trajectory call).
+Pass any of them as keywords when constructing a flow, e.g.
+`Flow(ocp, law; reltol=1e-10, alg=Tsit5())`.
+
+```@example main
+describe(:di)
+```
+
+`OptimalControl.get_full_strategy_registry()` — internal, not re-exported — is what `describe`
+and the constructor completion machinery actually query for the indirect side: it merges the
+direct-solve registry with `CTFlows.Flows.flow_registry()`, so `:sciml`/`:di` show up alongside
+`:collocation`/`:adnlp`/`:ipopt` in the same introspection tools.
+
+## CPU and GPU
+
+`method=:cpu`/`:gpu` — the same tokens as [`solve`](@ref solve-overview) — are passed **when
+constructing** a flow, not on the call:
+
+```julia
+f = Flow(ocp, law; method=:gpu)   # correct — a constructor keyword
+f(t0, x0, p0, tf; method=:gpu)    # wrong — MethodError, no such call-time keyword
+```
+
+## Where to go
+
+- [From an OCP](@ref flows-from-ocp) — the main path for indirect optimal control.
+- [From Hamiltonians and vector fields](@ref flows-from-hamiltonians) — building blocks below
+  the OCP layer.
+- [Simulating a controlled system](@ref flows-simulation) — no optimization, just integration.
+- [What you can get back from a flow](@ref flows-accessors) — inspection.
+- [Multi-phase flows](@ref flows-multi-phase) and [Constrained arcs](@ref flows-constrained-arcs)
+  — assembling several arcs into one trajectory.
+- [Writing a shooting function](@ref flows-shooting) — the payoff.
+- [Solve overview](@ref solve-overview) — the direct-method counterpart to everything here.
+- [Geometry](@ref geometry-overview) — the Lie-theoretic tools some of these constructors build on.

--- a/docs/src/flows/shooting.md
+++ b/docs/src/flows/shooting.md
@@ -1,4 +1,181 @@
-# [Shooting](@id flows-shooting)
+# [Writing a shooting function](@id flows-shooting)
 
-!!! warning "Under construction"
-    This page is being written. See the [specification reports](https://github.com/control-toolbox/OptimalControl.jl/tree/main/docs/reports).
+```@meta
+Draft = false
+```
+
+The payoff of everything else in this section: turn a flow into a root-finding problem for the
+unknown initial costate (and switching times, and free final time), and solve it.
+
+```@example main
+using OptimalControl
+using OrdinaryDiffEqTsit5
+using NonlinearSolve
+nothing # hide
+```
+
+## The shooting equation
+
+The PMP gives necessary conditions but not $p_0$ directly. Shooting turns "integrate the flow
+and check the boundary/transversality conditions" into a root-finding problem: guess the
+unknowns (initial costate, switching times, free final time), integrate, measure how far the
+result is from satisfying the conditions, and let a nonlinear solver close the gap.
+
+Worked example throughout: minimise the final time for $\ddot q = u$, $u \in [-1,1]$, from
+$(q,v)=(-1,0)$ to $(0,0)$ — bang-bang, one switch, free $t_f$. The reference solution is
+$p_0=(1,1)$, one switch at $t=1$, $t_f=2$.
+
+```@example main
+t0 = 0.0
+x0 = [-1.0, 0.0]
+xf = [0.0, 0.0]
+u_max = 1.0
+u_min = -1.0
+
+ocp = @def begin
+    tf ∈ R, variable
+    t ∈ [0, tf], time
+    x = (q, v) ∈ R², state
+    u ∈ R, control
+    -1 ≤ u(t) ≤ 1
+    q(0) == -1
+    v(0) == 0
+    q(tf) == 0
+    v(tf) == 0
+    ẋ(t) == [v(t), u(t)]
+    tf → min
+end
+
+f_max = Flow(ocp, (x, p, v) -> u_max)
+f_min = Flow(ocp, (x, p, v) -> u_min)
+nothing # hide
+```
+
+## A simple shooting function
+
+The simplest case has no switching — a single arc, fixed time. Out-of-place, the residual is
+just the target-state gap:
+
+```@example main
+function shoot_simple(p0)
+    xf_, _ = f_max(t0, x0, p0, 1.0; variable=2.0)   # arbitrary tf here — illustration only
+    return xf_ - xf
+end
+nothing # hide
+```
+
+## In-place, for the solver
+
+The real problem has 4 unknowns — $p_0$ (2), the switching time $t_1$, and $t_f$ — and 4
+residuals: the target state (2), the switching condition ($p_2=0$ where the bang-bang control
+switches, since $H_u=0$ there), and the free-time transversality $H(t_f)=-1$ (the Mayer cost is
+$t_f\to\min$, normal case):
+
+```@example main
+H(x, p, u) = p[1] * x[2] + p[2] * u - 1
+
+function shoot!(s, ξ)
+    p0 = ξ[1:2]
+    t1, tfv = ξ[3], ξ[4]
+    x1, p1 = f_max(t0, x0, p0, t1; variable=tfv)
+    xf_, pf = f_min(t1, x1, p1, tfv; variable=tfv)
+    s[1:2] = xf_ - xf
+    s[3] = p1[2]
+    s[4] = H(xf_, pf, u_min)
+    return nothing
+end
+
+s = zeros(4)
+shoot!(s, [1.0, 1.0, 1.0, 2.0])   # residual at the reference solution
+sqrt(sum(abs2, s))
+```
+
+## Solving it
+
+`NonlinearSolve` closes the gap from a perturbed guess:
+
+```@example main
+ξ_guess = [1.0, 1.0, 1.0, 2.0] .* 1.1
+prob = NonlinearProblem((s, ξ, _) -> shoot!(s, ξ), ξ_guess)
+sol = solve(prob, SimpleNewtonRaphson(); abstol=1e-10, reltol=1e-10)
+sol.u, sol.retcode
+```
+
+## `unsafe=true` inside the loop
+
+A nonlinear solver explores guesses that don't correspond to a real solution — some of them
+can make the flow's integration blow up. The default behaviour is to throw, which would abort
+the whole solve on the first bad guess:
+
+```@example main
+f_blowup = Flow(VectorField(x -> x^2))   # ẋ = x², genuinely diverges before t=1
+try
+    f_blowup(0.0, 10.0, 1.0)
+catch e
+    println(e)
+end
+```
+
+`unsafe=true` returns whatever the integrator produced instead of throwing — garbage, but a
+*value*, letting the shooting residual carry the failure forward as "very wrong" rather than
+crashing the solve:
+
+```@example main
+f_blowup(0.0, 10.0, 1.0; unsafe=true)
+```
+
+Inside a `shoot!`, wrap the flow calls with `unsafe=true` so an intermediate failure shows up as
+a large residual for the solver to step away from, not an exception that stops the search.
+
+## Free final time
+
+The transversality residual `H(xf_, pf, u_min) = -1` above **is** the free-final-time
+condition — no separate machinery needed beyond adding it as a residual. For a smooth
+(non-switching) free-final-time problem, `variable_costate=true` gives the extra adjoint
+directly if the transversality condition is stated in terms of $p_v(t_f)$ instead:
+
+```@example main
+xf_v, pf_v, pvf = f_max(t0, x0, [1.0, 1.0], 1.0; variable=2.0, variable_costate=true)
+pvf
+```
+
+## Multiple shooting and switching times
+
+The example above already has one: $t_1$ is an unknown alongside $p_0$ and $t_f$. Each
+additional switch adds one more unknown time and one more switching-condition residual — see
+[Multi-phase flows](@ref flows-multi-phase) for concatenating the corresponding flows once the
+times are known (or being solved for).
+
+## Getting a starting point from a direct solve
+
+Manufacturing a shooting guess by hand doesn't scale — the standard workflow is to solve the
+same problem directly first, then read `costate(sol)(t0)` off as the initial guess:
+
+```@example main
+using NLPModelsIpopt
+direct_sol = solve(ocp; display=false)
+p0_guess = costate(direct_sol)(0.0)
+p0_guess
+```
+
+## Checking against the direct solution
+
+```@example main
+objective(direct_sol)
+```
+
+```@example main
+indirect_sol = f_max((t0, sol.u[3]), x0, sol.u[1:2]; variable=sol.u[4])
+nothing # hide
+```
+
+Compare `state(indirect_sol)`/`objective`-derived quantities against the direct solve the same
+way [Solution object](@ref results-solution) already teaches — both describe the same optimal
+trajectory, found by two different methods.
+
+## See also
+
+- [From an OCP](@ref flows-from-ocp) — building the flows a shooting function is made of.
+- [Multi-phase flows](@ref flows-multi-phase) — concatenating the arcs once switching times are
+  known.
+- [Solve overview](@ref solve-overview) — the direct-method starting point used above.

--- a/docs/src/flows/simulation.md
+++ b/docs/src/flows/simulation.md
@@ -1,4 +1,141 @@
 # [Simulation](@id flows-simulation)
 
-!!! warning "Under construction"
-    This page is being written. See the [specification reports](https://github.com/control-toolbox/OptimalControl.jl/tree/main/docs/reports).
+```@meta
+Draft = false
+```
+
+Sometimes you don't want an optimum — you have a controlled system and a specific control
+(open-loop or feedback), and you want the trajectory it produces.
+
+```@example main
+using OptimalControl
+using OrdinaryDiffEqTsit5
+using NLPModelsIpopt
+using Plots
+nothing # hide
+```
+
+## The idea
+
+A controlled vector field $\dot x = f(x, u)$ plus a control — given as a function of time
+(open loop) or of state (feedback) — is enough to integrate a trajectory. No cost, no PMP, no
+`@def`: just `ControlledVectorField` and a law.
+
+## Open loop
+
+```@example main
+fc(x, u) = -x + u
+
+f_ol = Flow(ControlledVectorField(fc), OpenLoop(t -> 1.0))
+traj_ol = f_ol((0.0, 1.0), 1.0)
+state(traj_ol)(0.5)
+```
+
+!!! warning "`OpenLoop` is unconditionally non-autonomous"
+
+    The law must be `u(t)` (or `u(t, v)` with a variable) — always a function of time, never a
+    bare constant closure. `OpenLoop(() -> 1.0)` **builds without error** but fails on the
+    first call, with a bare `MethodError` far from the actual mistake:
+
+    ```@example main
+    bad_law = OpenLoop(() -> 1.0)   # constructs fine — the trap
+    try
+        Flow(ControlledVectorField(fc), bad_law)(0.0, 1.0, 1.0)
+    catch e
+        println(e)
+    end
+    ```
+
+    `OpenLoop(t -> 1.0)` above is the only correct spelling — there is no "autonomous open
+    loop" any more.
+
+## Closed loop (feedback)
+
+```@example main
+f_cl = Flow(ControlledVectorField(fc), ClosedLoop(x -> 0.5x))
+f_cl(0.0, 1.0, 1.0)
+```
+
+`DynClosedLoop` (the costate-carrying law kind) is rejected on a `ControlledVectorField` — it
+has no costate to carry:
+
+```@example main
+try
+    Flow(ControlledVectorField(fc), DynClosedLoop((x, p) -> x))
+catch e
+    println(e)
+end
+```
+
+## From an optimal control problem
+
+```@example main
+t0 = 0
+tf = 1
+x0 = [-1, 0]
+
+ocp = @def begin
+    t ∈ [t0, tf], time
+    x = (q, v) ∈ R², state
+    u ∈ R, control
+    x(t0) == x0
+    x(tf) == [0, 0]
+    ẋ(t) == [v(t), u(t)]
+    0.5∫(u(t)^2) → min
+end
+
+f_sim = Flow(ocp, OpenLoop(t -> 1.0))
+traj_ocp = f_sim((t0, tf), x0)
+nothing # hide
+```
+
+`Flow(ocp, OpenLoop(u))` returns a `ControlledFlow` whose trajectory **carries the objective**
+— you can evaluate a candidate control's cost directly:
+
+```@example main
+objective(traj_ocp)
+```
+
+A flow built without an OCP has no cost to report — calling `objective` on it is a
+`PreconditionError`, not a silent `0.0` or `NaN`:
+
+```@example main
+try
+    objective(traj_ol)
+catch e
+    println(e)
+end
+```
+
+## Inspecting the trajectory
+
+Same accessors as a `solve`-returned [`Solution`](@ref results-solution):
+
+```@example main
+state(traj_ocp)(0.5), control(traj_ocp)(0.5), time_grid(traj_ocp)
+```
+
+## Plotting it
+
+```@example main
+plot(traj_ocp)
+```
+
+See [Plot](@ref results-plot) for every keyword.
+
+## Point vs trajectory
+
+`f(t0, x0, tf)` returns the endpoint only; `f((t0, tf), x0)` returns the full trajectory — same
+convention as every other flow in this section.
+
+The trajectory's own type — `CTFlows.Trajectories.StateFlowTrajectory` — is not re-exported;
+never name it in your own code, only call the generic accessors on it.
+
+## See also
+
+- [Solution object](@ref results-solution) and [Plot](@ref results-plot) — the accessors used
+  above, in full.
+- [From an OCP](@ref flows-from-ocp) — the indirect-solving counterpart, where the law comes
+  from the PMP instead of being handed to you.
+- [Problems without a control](@ref modelling-without-control) — control-free problems, a
+  related but distinct case.

--- a/src/imports/ctflows.jl
+++ b/src/imports/ctflows.jl
@@ -15,6 +15,17 @@
 # which act on a bare `ComposedHamiltonian`.
 @reexport import CTFlows.Systems: control_law, pseudo_hamiltonian
 
+# Systems accessors — `system`/`integrator` stay unexported (too generic for
+# a DSL surface); reach them qualified as `CTFlows.Flows.system`/`.integrator`.
+@reexport import CTFlows.Systems:
+    hamiltonian,
+    hamiltonian_vector_field,
+    vector_field,
+    get_hamiltonian_gradient,
+    get_variable_gradient,
+    get_pseudo_hamiltonian_gradient,
+    get_pseudo_variable_gradient
+
 # Multi-phase flows — `Base.:*` is extended by `CTFlows.MultiPhase` to
 # concatenate flows, so it needs no re-export of its own.
 @reexport import CTFlows.MultiPhase:

--- a/test/suite/reexport/test_ctflows.jl
+++ b/test/suite/reexport/test_ctflows.jl
@@ -58,6 +58,36 @@ function test_ctflows()
             end
         end
 
+        Test.@testset "Systems accessors — gradients and vocabulary" begin
+            # Added alongside flows/accessors.md: hamiltonian/hamiltonian_vector_field/
+            # vector_field and the four get_*_gradient functions were exported by
+            # CTFlows.Systems but not re-exported here — an inconsistency with their
+            # siblings control_law/pseudo_hamiltonian above.
+            for f in (
+                :hamiltonian,
+                :hamiltonian_vector_field,
+                :vector_field,
+                :get_hamiltonian_gradient,
+                :get_variable_gradient,
+                :get_pseudo_hamiltonian_gradient,
+                :get_pseudo_variable_gradient,
+            )
+                Test.@testset "$f" begin
+                    Test.@test reexports(OptimalControl, f, CTFlows.Systems)
+                    Test.@test isdefined(CurrentModule, f)
+                end
+            end
+
+            # `system`/`integrator` deliberately stay unexported — too generic for
+            # a DSL surface — but must still resolve when qualified through Flows.
+            for f in (:system, :integrator)
+                Test.@testset "$f stays unexported" begin
+                    Test.@test !is_exported(OptimalControl, f)
+                    Test.@test isdefined(CTFlows.Flows, f)
+                end
+            end
+        end
+
         Test.@testset "MultiPhase" begin
             for f in (
                 :n_phases,


### PR DESCRIPTION
## Summary

Stacked on #866 (`docs/solve`, not yet merged) — base branch is `docs/solve`, not `main`, since PR 8 depends on PR 6 per the work board (sibling of #867, not stacked on it). Rebase onto `main` once #866 merges.

The largest section of the rewrite: 8 pages under `docs/src/flows/`, replacing the PR-2 stubs, covering the three jobs `Flow` does — indirect optimal control (PMP flow + shooting), simulation (integrate under a given control), and inspection (pull the Hamiltonian/vector field/control law back out of a flow). `simulation.md` and `accessors.md` have no predecessor on the old site; `accessors.md` was explicitly requested by the maintainer.

- **`overview.md`** (new): map of the section + PMP recap. Corrects the spec's own claim that a flow without an integrator loaded fails with a bare `MethodError` — verified live it's a clean `ExtensionError`. Corrects `method=:cpu`/`:gpu` to be a construction-time keyword, not call-time.
- **`from-ocp.md`**: the main path. Fixes all four spec-flagged stale patterns (`Flow(x->x)`, positional `Flow(ocp,u,g,μ)`, `augment=true`, `OptimalControl.Hamiltonian`). Harvests `test/suite/problems/test_hamiltonian_type.jl`'s non-stationary-law example for the total-vs-partial Hamiltonian section — already tested, better than anything in the attic.
- **`from-hamiltonians.md`**: full page from a 108-line skeleton, one section per constructor, all six verified live with real return types.
- **`simulation.md`** (new): `ControlledVectorField` + `OpenLoop`/`ClosedLoop`. Corrects the framing of `OpenLoop`'s non-autonomy — a zero-arg closure builds without error, only fails on first call, not rejected at construction as one might assume.
- **`accessors.md`** (new, user-requested): the availability table is the whole point — verified cell-by-cell live, correcting one spec cell (`hamiltonian(f)` genuinely throws on a `HamiltonianVectorField`-built flow) and noting the failure mode isn't uniform (`IncorrectArgument` in some cells, plain `MethodError` in others — a real API inconsistency stated honestly). Carries the PR's one code change: re-exporting `hamiltonian`/`hamiltonian_vector_field`/`vector_field`/the four `get_*_gradient` functions in `src/imports/ctflows.jl` (zero naming collisions confirmed), with the matching `test/suite/reexport/test_ctflows.jl` testset and `docs/reports/99-api-coverage.md` update.
- **`multi-phase.md`** (new, split out): worked example is the bang-bang time-optimal double integrator from `test/problems/double_integrator.jl`'s tested `_di_time_shoot_builder` fixture, matching the spec's own choice.
- **`constrained-arcs.md`**: fixes the positional-to-keyword constraint syntax. Documents a real subtlety found live: the `constraint=:label` (Symbol) spelling uses the OCP's own sign convention, not guaranteed to numerically agree with a hand-derived shooting `g`/`μ` pair — stated as a warning rather than assumed interchangeable.
- **`shooting.md`** (new): cross-checked the harvested attic material against the CI-tested fixtures in `test/problems/double_integrator.jl` and `test/helpers/shooting.jl` rather than trusting it at face value — needed exactly one fix (a missing `variable=tf`). `unsafe=true` demonstrated with a genuine synthetic blow-up ODE, since the double-integrator problem itself is too well-behaved to ever blow up.

**A genuine Documenter build quirk found and worked around** (recorded in detail in `docs/reports/05-flows-indirect.md`): inside Documenter's `@example` sandbox (a `baremodule`, not a regular `module`), `using OptimalControl` fails to bind `hamiltonian`/`hamiltonian_vector_field`/`vector_field`/the four `get_*_gradient` functions specifically — while `Flow`/`control_law`/`pseudo_hamiltonian` (re-exported the same way, from the same `CTFlows.Systems` module) bind fine. Isolated via extensive bisection (a direct 1-hop import works; the two-hop reexport-through-OptimalControl chain doesn't, only inside a `baremodule`); root cause not fully identified despite that investigation. Confirmed this does **not** affect real usage — a normal `using OptimalControl` in an ordinary session or module gets the correct binding every time. Worked around with a hidden (`# hide`), redundant direct import in `accessors.md`'s own setup block, invisible to readers and not something a real user needs.

## Test plan

- [x] `julia --project=docs docs/make.jl` — full rebuild, clean: 0 undefined-binding/no-docs/duplicate-docs warnings, all eight pages' `@example` blocks execute, 0 unresolved `@ref`s from them.
- [x] `npx vitepress build` on the Documenter output — site builds; spot-checked cross-links into #865/#866/#867's already-built anchors resolve in the built HTML.
- [x] `test/suite/flows/test_flow_api.jl` + `test/suite/problems/test_hamiltonian_type.jl` — 89/89 passed.
- [x] `test/suite/reexport/test_ctflows.jl` (with the new testset) — 73/73 passed.
- [x] `typos` — clean.
- [x] `docs/reports/05-flows-indirect.md` acceptance criteria re-checked against the real build (8/8 ticked, deviations/findings recorded explicitly rather than silently).

🤖 Generated with [Claude Code](https://claude.com/claude-code)