### PR TITLE
docs: getting started

### DIFF
--- a/docs/reports/README.md
+++ b/docs/reports/README.md
@@ -58,7 +58,7 @@ Status legend: ⬜ not started · 🟡 in progress · ✅ merged
 | 8 | [`docs: flows`](https://github.com/control-toolbox/OptimalControl.jl/pull/868) | Flows (indirect) | [`05`](05-flows-indirect.md) | 6 | ✅ |
 | 9 | [`docs: geometry`](https://github.com/control-toolbox/OptimalControl.jl/pull/869) | Geometry | [`06`](06-geometry.md) | 8 | ✅ |
 | 10 | [`docs: examples`](https://github.com/control-toolbox/OptimalControl.jl/pull/872) | Examples | [`08`](08-examples.md) | 8, 9 | 🟡 in review |
-| 11 | `docs: getting started` | Getting started + `index.md` | [`02`](02-getting-started.md) | 5–10 | ⬜ |
+| 11 | [`docs: getting started`](https://github.com/control-toolbox/OptimalControl.jl/pull/873) | Getting started + `index.md` | [`02`](02-getting-started.md) | 5–10 | 🟡 in review |
 | 12 | `docs: migration + cleanup` | Migration page, drop `docs/attic/` | [`10`](10-migration.md) §2 | all | ⬜ |
 
 PR 3 is code-only and independent — it can run in parallel with any docs PR.

--- a/docs/src-literate/tutorial.jl
+++ b/docs/src-literate/tutorial.jl
@@ -1,4 +1,4 @@
-# # OptimalControl.jl — a guided tour
+# # [OptimalControl.jl — a guided tour](@id getting-started-guided-tour)
 #
 #src ============================================================================
 #src SKELETON — v1 "socle" (~45 min). See .reports/tutorial-brainstorming.md.
@@ -23,7 +23,7 @@
 #md # !!! note "Run online"
 #md #     You can run this tutorial interactively in your browser — no installation required — by clicking the Binder badge below:
 #md #
-#md #     [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/control-toolbox/OptimalControl.jl/paderborn?urlpath=%2Fdoc%2Ftree%2Fdocs%2Fsrc%2Fnotebooks%2Ftutorial.ipynb)
+#md #     [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/control-toolbox/OptimalControl.jl/paderborn?urlpath=%2Fdoc%2Ftree%2Fdocs%2Fsrc%2Fnotebooks%2Fguided-tour.ipynb)
 
 #src ============================================================================
 # ## The problem, and installing the tools
@@ -84,7 +84,7 @@ xf = [0, 0];
 # ### The `@def` macro
 #
 #md # The [`@def`](@ref modelling-abstract-syntax) macro lets us write the problem almost exactly as the mathematics:
-#nb # The [`@def`](https://control-toolbox.org/OptimalControl.jl/stable/manual-abstract.html) macro lets us write the problem almost exactly as the mathematics:
+#nb # The [`@def`](https://control-toolbox.org/OptimalControl.jl/stable/modelling/abstract-syntax) macro lets us write the problem almost exactly as the mathematics:
 #
 # Each line of the `@def` block mirrors a piece of the mathematical formulation — time, state, control, dynamics, boundary conditions, then cost — in the same order one would write them on paper. Unicode symbols (`∈`, `R²`, `ẋ`, `∫`, `→`) make the code read like the maths; plain ASCII alternatives (`R^2`, `derivative`, `integral`, `=>`) are available for keyboards or workflows that prefer them.
 
@@ -105,7 +105,7 @@ end
 # ### The same problem with the macro-free (functional) API
 #
 #md # The [functional API](@ref modelling-functional-api) builds the *same* model step by step with plain functions — useful for programmatic problem generation or macro-free library code.
-#nb # The [functional API](https://control-toolbox.org/OptimalControl.jl/stable/manual-macro-free.html) builds the *same* model step by step with plain functions — useful for programmatic problem generation or macro-free library code.
+#nb # The [functional API](https://control-toolbox.org/OptimalControl.jl/stable/modelling/functional-api) builds the *same* model step by step with plain functions — useful for programmatic problem generation or macro-free library code.
 
 pre = OptimalControl.PreModel()
 
@@ -196,7 +196,7 @@ println("iterations, @init guess:   ", iterations(sol))
 # In this case both guesses give **1 iteration**: the double integrator is a *linear-quadratic* problem, so the NLP is quadratic and Ipopt solves it in a single step regardless of the starting point. Warm-starting only pays off on genuinely nonlinear problems — we will see this with the **Goddard rocket** in the next section.
 
 #md # For all the ways to specify an initial guess, see [Set an initial guess](@ref solve-initial-guess).
-#nb # For all the ways to specify an initial guess, see [Set an initial guess](https://control-toolbox.org/OptimalControl.jl/stable/manual-initial-guess.html).
+#nb # For all the ways to specify an initial guess, see [Set an initial guess](https://control-toolbox.org/OptimalControl.jl/stable/solve/initial-guess).
 #md # !!! note
 #md #     There is currently no way to initialise the costate directly — only state, control and variable can be provided through `@init`. The solver initialises the adjoint internally (as we saw above). Costate initialisation is a planned feature.
 #nb # **Note:** there is currently no way to initialise the costate directly — only state, control and variable can be provided through `@init`. The solver initialises the adjoint internally (as we saw above). Costate initialisation is a planned feature.
@@ -267,7 +267,7 @@ end
 # ### Choosing a solver is trivial
 #
 #md # `solve` uses the defaults (collocation, ADNLP modeler, Ipopt, CPU). Switching solver is just loading a package and passing a token (see [Solve a problem](@ref solve-overview)):
-#nb # `solve` uses the defaults (collocation, ADNLP modeler, Ipopt, CPU). Switching solver is just loading a package and passing a token (see [Solve a problem](https://control-toolbox.org/OptimalControl.jl/stable/manual-solve.html)):
+#nb # `solve` uses the defaults (collocation, ADNLP modeler, Ipopt, CPU). Switching solver is just loading a package and passing a token (see [Solve a problem](https://control-toolbox.org/OptimalControl.jl/stable/solve/choosing-a-method)):
 
 using MadNLP
 
@@ -309,7 +309,7 @@ plot!(plt, s1000; label="1000")
 
 # How much better is the optimal solution compared to a naive strategy? We simulate **full thrust until fuel depletion, then coast to apogee** — a bang-bang profile with no optimisation, just two ODE integrations with callbacks.
 
-using OrdinaryDiffEq   # ODE solver (callbacks for the bang-bang simulation)
+using OrdinaryDiffEqTsit5   # ODE solver (callbacks for the bang-bang simulation)
 
 ## Phase 1: u = 1, stop when m = mf (fuel depleted)
 bang1!(dx, x, p, t) = (dx[:] = F0(x) + F1(x))
@@ -383,7 +383,7 @@ catch e
 end
 
 #md # For the full GPU setup, see [Solve on GPU](@ref solve-gpu).
-#nb # For the full GPU setup, see [Solve on GPU](https://control-toolbox.org/OptimalControl.jl/stable/manual-solve-gpu.html).
+#nb # For the full GPU setup, see [Solve on GPU](https://control-toolbox.org/OptimalControl.jl/stable/solve/gpu).
 
 #src ============================================================================
 # ## The indirect method
@@ -435,7 +435,7 @@ end
 #
 # For the energy problem, $H = p_1 v + p_2 u - u^2/2$, so the maximiser is $u = p_2$.
 
-using OrdinaryDiffEq   # ODE solver (Hamiltonian flow)
+using OrdinaryDiffEqTsit5   # ODE solver (Hamiltonian flow)
 using NonlinearSolve   # nonlinear equations (shooting)
 
 ## maximising control in feedback form
@@ -473,7 +473,7 @@ plt_compare = plot(direct_sol; label="direct", size=(800, 600))
 plot!(plt_compare, indirect_sol; label="indirect")
 
 #md # See [Compute flows from optimal control problems](@ref flows-from-ocp) for the flow construction, and the [indirect simple shooting tutorial](@extref tutorial-indirect-simple-shooting).
-#nb # See [Compute flows from optimal control problems](https://control-toolbox.org/OptimalControl.jl/stable/manual-flow-ocp.html) for the flow construction, and the [indirect simple shooting tutorial](https://control-toolbox.org/Tutorials.jl/stable/).
+#nb # See [Compute flows from optimal control problems](https://control-toolbox.org/OptimalControl.jl/stable/flows/from-ocp) for the flow construction, and the [indirect simple shooting tutorial](https://control-toolbox.org/Tutorials.jl/stable/).
 
 #src ============================================================================
 # ## Going further
@@ -481,7 +481,7 @@ plot!(plt_compare, indirect_sol; label="indirect")
 #
 # **Variables & parameters.** Beyond the control, one can optimise **parameters** naturally, both in an OCP (the `variable` keyword of the DSL) and in a differential-constraint optimisation problem **without any control** (a *control-free* problem).
 #md # See [control-free problems](@ref examples-control-free).
-#nb # See [control-free problems](https://control-toolbox.org/OptimalControl.jl/stable/example-control-free.html).
+#nb # See [control-free problems](https://control-toolbox.org/OptimalControl.jl/stable/examples/control-free).
 #src NOTE(v1): parameter estimation is only *mentioned* here. The worked example is an
 #src   extension (out of v1) — see .reports/tutorial-brainstorming.md "Extensions futures".
 #
@@ -490,8 +490,8 @@ plot!(plt_compare, indirect_sol; label="indirect")
 #md # - Singular control (control-affine systems) — [singular control](@ref examples-singular-control)
 #md # - State constraint — [state constraint](@ref examples-state-constraint)
 #md # - Goddard problem — free final time, a singular arc, a state constraint and a structured shooting all at once — [Goddard tutorial](@extref Tutorials tutorial-goddard)
-#nb # - Singular control (control-affine systems) — <https://control-toolbox.org/OptimalControl.jl/stable/example-singular-control.html>
-#nb # - State constraint — <https://control-toolbox.org/OptimalControl.jl/stable/example-state-constraint.html>
+#nb # - Singular control (control-affine systems) — <https://control-toolbox.org/OptimalControl.jl/stable/examples/singular-control>
+#nb # - State constraint — <https://control-toolbox.org/OptimalControl.jl/stable/examples/state-constraint>
 #nb # - Goddard problem — free final time, a singular arc, a state constraint and a structured shooting all at once — <https://control-toolbox.org/Tutorials.jl/stable/tutorial-goddard.html>
 #
 #md # **Discrete continuation** — warm-starting across a family of problems (homotopy on a physical parameter), the grown-up version of the grid continuation above: [Discrete continuation](@extref Tutorials tutorial-continuation).

--- a/docs/src/getting-started/first-problem.md
+++ b/docs/src/getting-started/first-problem.md
@@ -1,4 +1,86 @@
-# [First problem](@id getting-started-first-problem)
+# [Your first problem](@id getting-started-first-problem)
 
-!!! warning "Under construction"
-    This page is being written. See the [specification reports](https://github.com/control-toolbox/OptimalControl.jl/tree/main/docs/reports).
+```@meta
+Draft = false
+```
+
+The shortest complete story: define a problem, solve it, look at the result. Fifteen lines,
+no options, no theory.
+
+## The problem
+
+A point mass moves on a line under a bounded force: state $x = (q, v)$ (position, velocity),
+scalar control $u$ (the force). Starting at rest at $q=-1$, reach $q=0$ at rest, in one unit of
+time, minimising the energy spent:
+
+```math
+\min \frac{1}{2}\int_0^1 u(t)^2\,\mathrm dt \quad\text{s.t.}\quad \dot q = v,\ \dot v = u,\
+\ x(0) = (-1, 0),\ x(1) = (0, 0).
+```
+
+## Define it
+
+```@example main
+using OptimalControl
+using NLPModelsIpopt
+
+ocp = @def begin
+    t ∈ [0, 1], time
+    x ∈ R², state
+    u ∈ R, control
+    x(0) == [-1, 0]
+    x(1) == [0, 0]
+    ẋ(t) == [x₂(t), u(t)]
+    ∫(0.5u(t)^2) → min
+end
+nothing # hide
+```
+
+See [Abstract syntax](@ref modelling-abstract-syntax) for what each line above means.
+
+## Solve it
+
+```@example main
+sol = solve(ocp)
+nothing # hide
+```
+
+## Look at it
+
+```@example main
+using Plots
+plot(sol; layout=:group)
+```
+
+(`layout=:group` sidesteps a known upstream bug in the default layout,
+[CTModels.jl#392](https://github.com/control-toolbox/CTModels.jl/issues/392) — see
+[Plotting](@ref results-plot) for the full story.)
+
+```@example main
+objective(sol), iterations(sol), successful(sol)
+```
+
+`control(sol)` is a function of time; because the control here is scalar, calling it returns a
+`Number`, not a length-1 vector — [1-D is a scalar](@ref modelling-abstract-syntax) throughout
+the package:
+
+```@example main
+control(sol)(0.5)
+```
+
+See [Solution](@ref results-solution) for the rest of what a solution carries, and
+[Plotting](@ref results-plot) for what else `plot` can show.
+
+## What just happened
+
+`solve(ocp)` was called with no method at all, so it ran the default:
+`(:collocation, :adnlp, :ipopt, :cpu)`. That default, what the four tokens mean, and how to
+override any of them, are the subject of [Choosing a method](@ref solve-choosing-a-method).
+
+## Next
+
+- [Choosing a method](@ref solve-choosing-a-method) — pick a different solver, modeler, or grid.
+- [Guided tour](@ref getting-started-guided-tour) — the same problem in more depth, plus the
+  indirect (Pontryagin) method and a second, harder problem.
+- [Example gallery](@ref examples-gallery) — worked problems covering singular arcs, state
+  constraints, free variables, and more.

--- a/docs/src/getting-started/installation.md
+++ b/docs/src/getting-started/installation.md
@@ -1,4 +1,141 @@
 # [Installation](@id getting-started-installation)
 
-!!! warning "Under construction"
-    This page is being written. See the [specification reports](https://github.com/control-toolbox/OptimalControl.jl/tree/main/docs/reports).
+```@meta
+Draft = false
+```
+
+## Install
+
+Open Julia's [interactive session (REPL)](https://docs.julialang.org/en/v1/manual/getting-started)
+and use the package manager:
+
+```julia
+using Pkg
+Pkg.add("OptimalControl")
+```
+
+!!! tip
+
+    If you are new to Julia, follow [this guideline](https://github.com/orgs/control-toolbox/discussions/64).
+
+`OptimalControl` alone is enough to define a problem with [`@def`](@ref modelling-abstract-syntax)
+and describe [solve strategies](@ref solve-choosing-a-method). Everything below is optional —
+loaded only when the feature it backs is actually used.
+
+## You will also need a solver
+
+`solve` needs an NLP solver backend loaded. `NLPModelsIpopt` is the default and the one used
+throughout this documentation:
+
+```julia
+using NLPModelsIpopt
+```
+
+Alternatives exist, each behind its own package:
+
+| Solver | Load |
+| --- | --- |
+| `:ipopt` (default) | `using NLPModelsIpopt` |
+| `:madnlp` | `using MadNLP` (CPU) or `using MadNLPGPU` (GPU) |
+| `:uno` | `using UnoSolver` |
+| `:madncl` | `using MadNCL` **and** `using MadNLP` (both) |
+| `:knitro` | `using NLPModelsKnitro` (commercial licence required) |
+
+See [Choosing a method](@ref solve-choosing-a-method) for how these combine with a discretizer,
+a modeler and a `:cpu`/`:gpu` parameter. Calling `solve` before the matching package is loaded
+raises an `ExtensionError` naming exactly which `using` statement to add — the same mechanism
+covers every optional piece on this page.
+
+## Optional: plotting
+
+```julia
+using Plots
+```
+
+unlocks `plot(sol)`. Without it:
+
+```julia
+julia> using OptimalControl
+julia> plot(sol)
+ERROR: ExtensionError: missing dependencies to plot solutions
+Missing  Plots
+Hint     Run: using Plots
+```
+
+See [Plotting](@ref results-plot).
+
+## Optional: flows
+
+Building a [`Flow`](@ref flows-overview) — indirect shooting, simulation, or inspecting a
+Hamiltonian vector field — needs an ODE integrator:
+
+```julia
+using OrdinaryDiffEqTsit5
+```
+
+!!! warning "The most common first failure"
+
+    Every page in the [Flows](@ref flows-overview) section opens with
+    `using OrdinaryDiffEqTsit5` for this reason: building a `Flow` before it is loaded is the
+    single most common trap for newcomers to this part of the package. It fails cleanly rather
+    than silently:
+
+    ```julia
+    julia> using OptimalControl
+    julia> φ = Flow(ocp, u)
+    ERROR: ExtensionError: missing dependencies to access SciML options metadata
+    Missing  OrdinaryDiffEqTsit5
+    Hint     Run: using OrdinaryDiffEqTsit5
+    ```
+
+## Optional: saving solutions
+
+```julia
+using JLD2   # format=:JLD (default)
+using JSON3  # format=:JSON
+```
+
+unlock `export_ocp_solution`/`import_ocp_solution`. Without the matching one:
+
+```julia
+julia> export_ocp_solution(sol; format=:JLD)
+ERROR: ExtensionError: missing dependencies to export solutions to JLD2 format
+Missing  JLD2
+Hint     Run: using JLD2
+```
+
+See [Save & load](@ref results-save-load).
+
+## Optional: GPU
+
+```julia
+using ExaModels
+using MadNLPGPU
+using CUDA
+```
+
+NVIDIA GPUs only; the problem's dynamics must be written coordinatewise. Missing any of the
+three raises the same `ExtensionError` as above, naming whichever is missing first. See
+[GPU](@ref solve-gpu) for the constraints and check `CUDA.functional()` before assuming a
+`:gpu` solve will actually run on the device.
+
+## Checking your setup
+
+Loading everything and calling `methods()` is a quick way to confirm the install is sound —
+if this runs without error, `OptimalControl` and every optional piece above are wired in:
+
+```@example main
+using OptimalControl
+using NLPModelsIpopt
+using Plots
+using OrdinaryDiffEqTsit5
+using JLD2
+using JSON3
+
+methods()
+```
+
+## See also
+
+- [Your first problem](@ref getting-started-first-problem) — model, solve and plot one, end to end.
+- [Choosing a method](@ref solve-choosing-a-method) — the full discretizer/modeler/solver/parameter picture.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -4,22 +4,14 @@ The OptimalControl.jl package is the root package of the [control-toolbox ecosys
 
 ## Installation
 
-To install OptimalControl.jl, please [open Julia's interactive session (known as REPL)](https://docs.julialang.org/en/v1/manual/getting-started) and use the Julia package manager:
-
-```julia
-using Pkg
-Pkg.add("OptimalControl")
-```
-
-!!! tip
-
-    If you are new to Julia, please follow this [guidelines](https://github.com/orgs/control-toolbox/discussions/64).
+See [Installation](@ref getting-started-installation) — one package to add, plus a handful of
+optional pieces (a solver, plotting, flows, saving) loaded only when you use them.
 
 ## Basic usage
 
 Let us model, solve and plot a simple optimal control problem.
 
-```julia
+```@example main
 using OptimalControl
 using NLPModelsIpopt
 using Plots
@@ -35,13 +27,27 @@ ocp = @def begin
 end
 
 sol = solve(ocp)
-plot(sol)
+plot(sol; layout=:group)
 ```
 
-- For more details, see the [example gallery](@ref examples-gallery).  
+- For more details, see the [energy minimisation example](@ref examples-double-integrator-energy).  
 - The `@def` macro defines the problem. See the [abstract syntax guide](@ref modelling-abstract-syntax).  
 - The `solve` function has many options. See the [solve overview](@ref solve-overview).  
 - The `plot` function is flexible. See the [plot guide](@ref results-plot).
+
+## Where to go next
+
+| Section | What's there |
+| --- | --- |
+| [Getting started](@ref getting-started-guided-tour) | Install, solve your first problem, then a longer guided tour covering both the direct and indirect methods. |
+| [Modelling](@ref modelling-formulation) | The `@def` DSL, the macro-free functional API, control-free (parameter estimation) problems, and problem introspection. |
+| [Solve (direct)](@ref solve-overview) | Discretize-and-transcribe methods: choosing a strategy, initial guesses, options, explicit mode, GPU. |
+| [Results](@ref results-solution) | Read a `Solution` — trajectories, costate, duals, status — plot it, save it, reload it. |
+| [Flows (indirect)](@ref flows-overview) | The Pontryagin Maximum Principle as code: build, integrate, and shoot with Hamiltonian flows. |
+| [Geometry](@ref geometry-overview) | The Lie-theoretic tools (`Lift`, `ad`, `Poisson`, `@Lie`) behind singular-control problems. |
+| [Examples](@ref examples-gallery) | Six worked problems, direct and indirect, from energy minimisation to state constraints. |
+| [API reference](@ref api-modelling) | Every re-exported symbol, organised by theme. |
+| [Migrating to v2.1](@ref migration) | What changed since v2.0 and how to update your code. |
 
 ## Mathematical formulation
 


### PR DESCRIPTION
## Summary

- Writes `getting-started/installation.md`: all four optional-dependency families (solver, plotting, flows, saving, GPU) with live-verified `ExtensionError` messages and a working-setup smoke test.
- Writes `getting-started/first-problem.md`: the shortest complete define/solve/plot story, `Draft = false`.
- Rewrites `index.md` per spec: Installation moved out to its own page, Basic usage now an executed `@example`, adds a "Where to go next" table surveying every top-level section, repoints the four stale cross-refs.
- Audits `docs/src-literate/tutorial.jl` (the guided tour) against every v2.0→v2.1 trap in [`00-cahier-des-charges.md`](docs/reports/00-cahier-des-charges.md) §8.2 and fixes what it found:
  - missing `@id getting-started-guided-tour` anchor (every `@ref` to the guided tour was silently failing to resolve)
  - 9 stale notebook-only URLs still pointing at the old flat site (`manual-*.html`, `example-*.html`) → new nested VitePress paths
  - Binder badge pointing at the old notebook filename
  - `using OrdinaryDiffEq` → the lighter `using OrdinaryDiffEqTsit5`, matching the Flows section convention

Along the way: found and worked around a known upstream bug where bare `plot(sol)` breaks under the default `:split` layout ([CTModels.jl#392](https://github.com/control-toolbox/CTModels.jl/issues/392)) — used `layout=:group` everywhere in this PR, matching the existing `results/plot.md` convention.

Closes the last content gap before PR 12 (migration + cleanup), which depends on this.

## Test plan

- [x] `julia --project=docs docs/make.jl` runs clean end to end (exit 0, zero unresolved `@ref`s in any file this PR touches)
- [x] Every executed code block in `installation.md` and `first-problem.md` live-verified against the current package (not just re-read)
- [x] Notebook and script regenerate at the new `getting-started/` paths; Binder badge updated to match

🤖 Generated with [Claude Code](https://claude.com/claude-code)