### PR TITLE
ci(docs): restore the 'run documentation' label gate

### DIFF
--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -8,32 +8,18 @@ on:
       - 'v[0-9]+\.[0-9]+\.[0-9]+'
   pull_request:
     types: [labeled, opened, synchronize, reopened]
-    # The docs build is the only job that executes the `@example` blocks and resolves
-    # the `@ref`/`@extref` links, so it is the only check that can catch a broken page.
-    # It used to be reachable solely through the 'run documentation' label, and in
-    # practice the label was never applied: the twelve PRs of the v2.1 documentation
-    # rewrite all merged without a single build. These paths are everything the built
-    # site depends on — pages, docstrings pulled into the API reference, and the doc
-    # environment itself — so a PR touching any of them now builds automatically.
-    # A PR touching none of them cannot change the output, which is why dropping the
-    # label requirement for those loses nothing.
-    paths:
-      - 'docs/**'
-      - 'src/**'
-      - 'Project.toml'
-      - '.github/workflows/Documentation.yml'
-
+  
 jobs:
   call:
-    # With the path filter above, every pull_request event that gets here is already
-    # documentation-relevant, so the label is no longer a gate. It stays usable as a
-    # manual re-run handle. The one case still worth guarding is 'labeled': it fires
-    # once per label added, so reacting to any label would re-run this job on every
-    # subsequent label add.
+    # A 'labeled' event fires once per label added, and re-evaluates against the PR's
+    # *current* full label set — so adding several labels in a row would otherwise
+    # re-run this job on every subsequent label add. Only react to 'labeled' when it's
+    # this specific label; for other trigger types (opened/synchronize/reopened), fall
+    # back to checking the current label set as before.
     if: >
       github.event_name != 'pull_request' ||
-      github.event.action != 'labeled' ||
-      github.event.label.name == 'run documentation'
+      (github.event.action == 'labeled' && github.event.label.name == 'run documentation') ||
+      (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'run documentation'))
     uses: control-toolbox/CTActions/.github/workflows/documentation.yml@main
     with:
       use_ct_registry: true


### PR DESCRIPTION
## Why

#875 removed the `run documentation` label gate and replaced it with an automatic `paths`
trigger. The premise was that the label had never been applied to any of the twelve
documentation pull requests, and that this was an oversight.

**It was not an oversight — the label is the mechanism.** It exists so documentation builds are
started deliberately instead of on every push, and the rewrite was verified locally with the
intent of finalising the docs before running builds online. #875 removed a control that was
working as designed.

## What changes

`.github/workflows/Documentation.yml` goes back to its pre-#875 state, byte for byte. The
`paths` filter goes away with the rest: once a human decides when the job runs, a path filter
decides nothing.

The restored condition is worth restating, because it is more carefully built than it looks:

```yaml
if: >
  github.event_name != 'pull_request' ||
  (github.event.action == 'labeled' && github.event.label.name == 'run documentation') ||
  (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'run documentation'))
```

- On a `labeled` event it reacts **only** to `run documentation` — otherwise adding three labels
  in a row would start three builds.
- On `opened` / `synchronize` / `reopened` it checks that the PR **currently carries** the label.
  So a build is opted into once, and then repeats on every push for as long as the label stays.

This also puts the repository back in line with the Handbook's `Documentation.yml` template
(`VITEPRESS-DOC.md:484-493`), which #875 had made OptimalControl the only package to diverge
from.

## What is kept

`docs/src/index.md` keeps the `Draft = false` that #875 added. It is independent of the trigger,
and without it the landing page's five `@example` blocks execute nowhere — not in CI, not
locally. That one was a real gap.

## Verification

This PR touches only the workflow. For a `pull_request` event GitHub evaluates the workflow file
from the PR head, so the restored file governs this PR too: no `Documentation` job should start
here unless the `run documentation` label is added. That is the check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)