### PR TITLE
docs: make five example blocks show what they claim

### DIFF
--- a/docs/src/flows/accessors.md
+++ b/docs/src/flows/accessors.md
@@ -12,14 +12,6 @@ the map of what you can pull back out, and from which kind of flow.
 using OptimalControl
 using OrdinaryDiffEqTsit5
 using NLPModelsIpopt
-import CTFlows.Systems: # hide
-    hamiltonian, # hide
-    hamiltonian_vector_field, # hide
-    vector_field, # hide
-    get_hamiltonian_gradient, # hide
-    get_variable_gradient, # hide
-    get_pseudo_hamiltonian_gradient, # hide
-    get_pseudo_variable_gradient # hide
 nothing # hide
 ```
 

--- a/docs/src/flows/overview.md
+++ b/docs/src/flows/overview.md
@@ -68,6 +68,7 @@ Every flow needs an ODE integrator, and none is a hard dependency — load one, 
 
 ```@example main
 using OptimalControl
+using OrdinaryDiffEqTsit5
 using NLPModelsIpopt
 
 t0 = 0
@@ -84,20 +85,32 @@ ocp = @def begin
     0.5∫(u(t)^2) → min
 end
 
-try
-    Flow(ocp, (x, p) -> p[2])
-catch e
-    println(e)
-end
-```
-
-```@example main
-using OrdinaryDiffEqTsit5
 f = Flow(ocp, (x, p) -> p[2])
 nothing # hide
 ```
 
-Every page in this section opens with `using OrdinaryDiffEqTsit5` — no exceptions.
+Every page in this section opens with `using OrdinaryDiffEqTsit5` — no exceptions. Forget it
+and `Flow` says so at construction time, naming the `using` to add:
+
+```julia
+julia> f = Flow(ocp, (x, p) -> p[2])
+ERROR: ExtensionError → top-level scope, REPL[6]:1
+│
+│  missing dependencies to access SciML options metadata
+│
+│  Missing  OrdinaryDiffEqTsit5
+│
+│  Context  Load OrdinaryDiffEqTsit5, OrdinaryDiffEq, or DifferentialEquations to activate the CTSolversSciMLIntegrator extension.
+│  Hint     Run: using OrdinaryDiffEqTsit5
+└─
+```
+
+!!! note "Why that block is not executed"
+
+    The documentation build loads `OrdinaryDiffEq` once, for the whole site, and a Julia
+    extension stays armed for the rest of the session — so no page here can demonstrate this
+    failure live. The transcript above comes from a session loading `OptimalControl` and
+    `NLPModelsIpopt` and nothing else.
 
 ## Choosing an integrator and its options
 

--- a/docs/src/migration.md
+++ b/docs/src/migration.md
@@ -48,7 +48,7 @@ never write a flow. See [Installation](@ref getting-started-installation) and
 | `OptimalControl.VectorField`, `OptimalControl.Hamiltonian`, … | `VectorField`, `Hamiltonian`, … | exported at top level since v2.1.0-beta; the qualified form still works, it's just no longer necessary |
 | `Lie(X, f)` | `ad(X, f)` | renamed; `Lie(...)` now throws |
 | `X ⋅ f` | `ad(X, f)` | removed, no operator alias; `X ⋅ f` now throws |
-| `HamiltonianLift` | `Lift(f)` to build; `CTLie.LiftedHamiltonianFunction` to name the type | renamed **and** re-parented — see [What changed meaning silently](@ref migration-silent) |
+| `HamiltonianLift` | `Lift(f)` to build; `OptimalControl.LiftedHamiltonianFunction` to name the type | renamed **and** re-parented — see [What changed meaning silently](@ref migration-silent) |
 | `autonomous=`, `variable=`, `inplace=` (constructor keywords) | `is_autonomous=`, `is_variable=`, `is_inplace=` | prefixed, on `VectorField`, `Hamiltonian`, `@Lie`, and friends |
 | `Flow(f)` with `f::Function` | `Flow(VectorField(f))`, `Flow(Hamiltonian(f))`, `Flow(HamiltonianVectorField(f))` | the bare function no longer says what kind of flow to build |
 | `Flow(ocp, u, g, μ)` (3 positional) | `Flow(ocp, u; constraint=g, multiplier=μ)` | keywords, and they come as a pair |

--- a/docs/src/results/plot.md
+++ b/docs/src/results/plot.md
@@ -294,9 +294,9 @@ time_grid(sol_flow)
 ```
 
 For a denser plot, pass `saveat` **when constructing the flow**, not on the call — the call
-itself only accepts `variable`/`unsafe` (and `augment`, for costate augmentation). `dense=false`
-is required alongside `saveat`, since dense output and `saveat` conflict at the integrator
-level:
+itself only accepts `variable`/`unsafe` (and `variable_costate`, for costate augmentation).
+`dense=false` is required alongside `saveat`, since dense output and `saveat` conflict at the
+integrator level:
 
 ```@example main
 fine_grid = range(t0, tf, 100)

--- a/docs/src/solve/choosing-a-method.md
+++ b/docs/src/solve/choosing-a-method.md
@@ -30,6 +30,25 @@ There are 12 methods: every `{adnlp, exa} × {ipopt, madnlp, uno, madncl, knitro
 This list is not fixed prose to memorize — it is exactly what `methods()` returns, so it's
 printed live rather than quoted as a number anywhere on this page.
 
+## A problem to try them on
+
+Every `solve` call on this page uses the same problem — the double integrator, with its
+dynamics written coordinatewise so that both the `:adnlp` and the `:exa` modeler accept it:
+
+```@example main
+ocp = @def begin
+    t ∈ [0, 1], time
+    x = (q, v) ∈ R², state
+    u ∈ R, control
+    x(0) == [-1, 0]
+    x(1) == [0, 0]
+    ∂(q)(t) == v(t)
+    ∂(v)(t) == u(t)
+    ∫(0.5u(t)^2) → min
+end
+nothing # hide
+```
+
 ## Partial descriptions
 
 `solve(ocp, :madnlp)` doesn't need the other three tokens — they're completed for you.
@@ -112,29 +131,49 @@ describe(:cpu)
 
 `:collocation` accepts a `scheme` option (alias `disc_method`):
 
-| Value | Notes |
-| --- | --- |
-| `:trapeze` | second-order |
-| `:midpoint` | second-order, **default** |
-| `:euler`, `:euler_explicit`, `:euler_forward` | first-order, explicit |
-| `:euler_implicit`, `:euler_backward` | first-order, implicit |
-| `:gauss_legendre_2` | fourth-order, **`:adnlp` modeler only** |
-| `:gauss_legendre_3` | sixth-order, **`:adnlp` modeler only** |
-| `:variable` | variable-step ODE-based discretization |
+| Value | Notes | `:adnlp` | `:exa` |
+| --- | --- | :-: | :-: |
+| `:trapeze` | second-order | ✅ | ✅ |
+| `:midpoint` | second-order, **default** | ✅ | ✅ |
+| `:euler` | first-order, explicit | ✅ | ✅ |
+| `:euler_implicit` | first-order, implicit | ✅ | ✅ |
+| `:euler_explicit`, `:euler_forward` | aliases of `:euler` | ✅ | ✗ |
+| `:euler_backward` | alias of `:euler_implicit` | ✅ | ✗ |
+| `:gauss_legendre_2` | fourth-order | ✅ | ✗ |
+| `:gauss_legendre_3` | sixth-order | ✅ | ✗ |
+| `:variable` | variable-step, ODE-based | ✗ | ✗ |
 
 plus `grid_size` (default `250`) or an explicit, possibly non-uniform, `time_grid`.
 
-!!! warning "Gauss-Legendre schemes are `:adnlp`-only"
+Every cell above was checked by solving with that scheme. Two of the results need spelling out.
 
-    `:gauss_legendre_2`/`:gauss_legendre_3` are rejected under `:exa` — confirmed live:
+!!! warning "Under `:exa`, only the four canonical names work"
+
+    `:exa` takes `:trapeze`, `:midpoint`, `:euler` and `:euler_implicit`, and nothing else.
+    Both Gauss-Legendre schemes are out — and so are the aliases, which is the surprising part:
+    `:euler_forward` is rejected where `:euler` is accepted, though under `:adnlp` the two name
+    the same scheme. Confirmed live:
 
     ```@example main
+    using Logging
+    # ExaModels warns about a deprecated `ExaCore()` call on every model it
+    # builds; silenced here so the scheme error is the only output.
     try
-        solve(ocp, :exa; scheme=:gauss_legendre_2, display=false)
+        with_logger(NullLogger()) do
+            solve(ocp, :exa; scheme=:gauss_legendre_2, display=false)
+        end
     catch e
         println(e)
     end
     ```
+
+!!! warning "`:variable` is advertised but does not run"
+
+    The `describe(:collocation)` output above lists `:variable`, and the registry accepts it,
+    but no modeler can use it: the scheme dispatches to `CTDirect.VariableStepODE`, whose
+    implementation is not compiled into CTDirect, so a solve raises
+    `UndefVarError(:VariableStepODE, …, CTDirect)` rather than any typed error. It is kept in
+    the table only because the registry listing above advertises it.
 
 ## Advanced: the strategy registry
 


### PR DESCRIPTION
## Why

The first CI build confirmed what a local build had suggested: five pages render, publish, and
are wrong. None of them fails the build — that is the point. Every fix here was checked by
running the code in the `docs/` environment, not by reading it, and two of them turned out
differently from what the review predicted.

## The five

**1. `solve/choosing-a-method.md` published an `UndefVarError`.** No `ocp` was defined anywhere
on the page, and both demonstrations wrap their call in `try`/`catch`, so the missing binding was
swallowed and printed as the result:

> …so this raises `AmbiguousDescription` rather than silently picking one:
> `UndefVarError(:ocp, 0x000000000000b0e3, Main)`

and again eighty lines down under *"confirmed live"*.

The page now has a running example — a double integrator, dynamics written coordinatewise so
both `:adnlp` and `:exa` accept it. It is a **visible** `@example`, not the hidden `@setup` the
review first proposed: a hidden binding keeps the page from being copy-pasted, which moves the
`UndefVarError` from the built page to the reader's REPL instead of removing it.

**2. `flows/overview.md`'s "no integrator loaded" demonstration could not fail.** `make.jl` loads
`OrdinaryDiffEq` for the whole site, and a Julia extension stays armed for the session, so the
`try` block succeeded and the page rendered a fully constructed `OptimalControlFlow` where it
promised an `ExtensionError`.

No page in this build can demonstrate it, so the block becomes an inert transcript, captured in a
session loading `OptimalControl` and `NLPModelsIpopt` and nothing else — plus a note explaining
*why* it is inert, so it is not turned back into an `@example` later. The claim itself holds:
`Flow(ocp, law)` throws `CTBase.Exceptions.ExtensionError` at construction time, with
`Hint  Run: using OrdinaryDiffEqTsit5`.

**3. `results/plot.md` contradicted the migration page.** It said a flow call "only accepts
`variable`/`unsafe` (and `augment`, for costate augmentation)". `augment` does not exist:
`CTFlows.jl/src/Flows/calling.jl:92` declares `variable`, `unsafe`, `variable_costate`. The
migration page says so twice (`:81`, `:243`), and `augment=` is on the banned-spelling list in
§8.2.

**4. `flows/accessors.md` carried a hidden import.** Eight lines of `import CTFlows.Systems:` with
`# hide` on every one — needed before #868 re-exported all seven accessors
(`src/imports/ctflows.jl:20-27`, with a testset). The page was quietly working around a re-export
it should have been demonstrating. Removed; the built page now returns `0.5` from
`hamiltonian(f)` with no import at all.

**5. `migration.md` spelled one type two ways, on the same page.** `:51` wrote
`CTLie.LiftedHamiltonianFunction`, `:139` wrote `OptimalControl.LiftedHamiltonianFunction`. The
four `geometry/` pages and the test suite (`test/suite/reexport/test_ctlie.jl:96-108`) use the
second form, and the same table two rows down states the rule — *write against `OptimalControl`*.
The transcript at `:196` keeps `CTLie.` because that is verbatim what `src/deprecated.jl:63`
prints.

## What re-reading the outputs found

With the page executing for the first time, the scheme table turned out to be wrong on **four
rows**, not one. Sweeping all ten schemes against both modelers, each cell obtained by actually
solving:

| | `:adnlp` | `:exa` |
| --- | :-: | :-: |
| `:trapeze`, `:midpoint`, `:euler`, `:euler_implicit` | ✅ | ✅ |
| `:euler_explicit`, `:euler_forward`, `:euler_backward` | ✅ | ✗ |
| `:gauss_legendre_2`, `:gauss_legendre_3` | ✅ | ✗ |
| `:variable` | ✗ | ✗ |

Two surprises. **The aliases are rejected under `:exa` where their canonical form is accepted** —
`:euler_forward` fails where `:euler` succeeds — though under `:adnlp` the two name one scheme;
the table presented them as interchangeable. And **`:variable` is rejected everywhere**: it
dispatches to `CTDirect.VariableStepODE` (`CTDirect.jl/src/DOCP_data.jl:338-340`) whose
implementation is not compiled in — `CTDirect.jl/src/CTDirect.jl:63` has the `include` commented
out — so a solve raises `UndefVarError(:VariableStepODE, …, CTDirect)`.

`:variable` **stays** in the table, marked unavailable on both sides, because
`describe(:collocation)` runs ten lines above on the same page and still advertises it. Removing
the row would leave two adjacent blocks contradicting each other. It comes out when CTDirect is
fixed.

## Upstream, not fixed here

- **`CTDirect`** — `:variable` advertised by the registry, not compiled in, `UndefVarError`.
  The most serious of the three: it reaches anyone who follows the docs.
- **`CTParser`** — an unknown scheme is thrown as a bare `String`
  (`onepass.jl:941`, `:1035`, `:1106`). `typeof(e) === String`, outside the seven typed
  exceptions, and a `catch` cannot discriminate on it.
- **`CTParser`** — `onepass.jl:1483` calls the deprecated `ExaCore()`. This page is the first in
  the site to run `:exa` live (`solve/gpu.md` is `Draft = true`, `solve/options.md`'s `:exa`
  blocks are inert), so without intervention the published page would carry a deprecation warning
  *and the build machine's package path* — `/home/runner/.julia/packages/ExaModels/…` in CI. It
  is silenced in the block **visibly**, with a comment naming the cause; hiding it behind
  `# hide` would have been the same mistake as fix 4 above. The scaffolding comes out when
  CTParser is fixed.

## Not done here

The site uses `println(e)` **30 times** and the Handbook's canonical exception form
(`VITEPRESS-DOC.md:241-260` — `@repl` + `try/catch # hide` +
`showerror(IOContext(stdout, :color => false), e) # hide`) **zero times**, where CTBase applies it
24/24, CTSolvers 13/13 and CTModels 10/10. That is the same theme as this PR but thirty more
blocks, so it goes in its own change.

## Verification

`julia --project=docs docs/make.jl` locally: **786 log lines, 12 errors, 186 warnings, 166
unresolved `@ref`, zero failing `@example` block**, exit 0 — identical to the baseline from #875.
The 166 are the generated API reference and are untouched here. Both corrected outputs were read
in the built HTML, not only counted in the log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
