### PR TITLE
docs: display exceptions the way the Handbook prescribes

### DIFF
--- a/docs/src/flows/accessors.md
+++ b/docs/src/flows/accessors.md
@@ -106,12 +106,12 @@ Hamiltonian-shaped, so none of the four Hamiltonian-side accessors apply; use
 vector_field(Flow(VectorField(x -> -x)))
 ```
 
-```@example main
-try
-    hamiltonian(Flow(HamiltonianVectorField((x, p) -> (p, -x))))
-catch e
-    println(e)
-end
+```@repl main
+try # hide
+hamiltonian(Flow(HamiltonianVectorField((x, p) -> (p, -x))))
+catch e # hide
+showerror(IOContext(stdout, :color => false), e) # hide
+end # hide
 ```
 
 ## The underlying system and integrator

--- a/docs/src/flows/constrained-arcs.md
+++ b/docs/src/flows/constrained-arcs.md
@@ -52,12 +52,12 @@ xf
 
 `constraint=`/`multiplier=` must be given **as a pair** — one without the other is rejected:
 
-```@example main
-try
-    Flow(ocp, law; constraint=:vmax)
-catch e
-    println(e)
-end
+```@repl main
+try # hide
+Flow(ocp, law; constraint=:vmax)
+catch e # hide
+showerror(IOContext(stdout, :color => false), e) # hide
+end # hide
 ```
 
 ## Three ways to give the constraint
@@ -82,12 +82,12 @@ typeof(f_sym)
 
 An unknown label is rejected, not silently accepted:
 
-```@example main
-try
-    Flow(ocp, law; constraint=:nope, multiplier=μ)
-catch e
-    println(e)
-end
+```@repl main
+try # hide
+Flow(ocp, law; constraint=:nope, multiplier=μ)
+catch e # hide
+showerror(IOContext(stdout, :color => false), e) # hide
+end # hide
 ```
 
 !!! warning "The `Symbol` form uses the model's own sign convention"
@@ -112,12 +112,12 @@ constraint order requires one.
 
 ## Positional form is gone
 
-```@example main
-try
-    Flow(ocp, law, (x, u) -> g(x), μ)
-catch e
-    println(e)
-end
+```@repl main
+try # hide
+Flow(ocp, law, (x, u) -> g(x), μ)
+catch e # hide
+showerror(IOContext(stdout, :color => false), e) # hide
+end # hide
 ```
 
 ## Partial Hamiltonian on a constrained arc
@@ -129,19 +129,19 @@ optimal.
 
 ## Control-free flows reject constraints
 
-```@example main
+```@repl main
 ocp_cf = @def begin
     t ∈ [t0, tf], time
     x ∈ R, state
     x(t0) == 1.0
     ẋ(t) == -x(t)
     ∫(x(t)^2) → min
-end
-try
-    Flow(ocp_cf; constraint=(x, u) -> 1.0, multiplier=(x, p) -> 1.0)
-catch e
-    println(e)
-end
+end;
+try # hide
+Flow(ocp_cf; constraint=(x, u) -> 1.0, multiplier=(x, p) -> 1.0)
+catch e # hide
+showerror(IOContext(stdout, :color => false), e) # hide
+end # hide
 ```
 
 ## See also

--- a/docs/src/flows/from-hamiltonians.md
+++ b/docs/src/flows/from-hamiltonians.md
@@ -69,12 +69,16 @@ fphvf = Flow(PseudoHamiltonianVectorField(htildevf), DynClosedLoop(law))
 fphvf(0.0, 1.0, 0.0, 1.0)
 ```
 
-```@example main
-try
-    Flow(PseudoHamiltonianVectorField(htildevf), DynClosedLoop(law); hamiltonian_type=:partial)
-catch e
-    println(e)
-end
+```@repl main
+try # hide
+Flow(
+    PseudoHamiltonianVectorField(htildevf),
+    DynClosedLoop(law);
+    hamiltonian_type=:partial,
+)
+catch e # hide
+showerror(IOContext(stdout, :color => false), e) # hide
+end # hide
 ```
 
 ## From a SciML problem
@@ -91,12 +95,12 @@ nothing # hide
 SciML-backed flows are always `NonFixed` — even with no real free variable, a call needs
 `variable=nothing`:
 
-```@example main
-try
-    f_fun(0.0, [1.0], 1.0)
-catch e
-    println(e)
-end
+```@repl main
+try # hide
+f_fun(0.0, [1.0], 1.0)
+catch e # hide
+showerror(IOContext(stdout, :color => false), e) # hide
+end # hide
 ```
 
 ```@example main
@@ -123,12 +127,12 @@ fg(0.0, 1.0, 1.0)
 The stale form fails two ways at once — there is no `Flow(::Function)` at all, and even fixed
 to the right type, the keyword itself changed name:
 
-```@example main
-try
-    VectorField(g; autonomous=false)
-catch e
-    println(e)
-end
+```@repl main
+try # hide
+VectorField(g; autonomous=false)
+catch e # hide
+showerror(IOContext(stdout, :color => false), e) # hide
+end # hide
 ```
 
 `is_inplace=` similarly declares an in-place (mutating, `f!(dx, x)`) vs out-of-place

--- a/docs/src/flows/from-ocp.md
+++ b/docs/src/flows/from-ocp.md
@@ -118,12 +118,12 @@ xf_v, pf_v = fc(t0c, x0c, p0c, tf_val; variable=tf_val)
 xf_v
 ```
 
-```@example main
-try
-    fc(t0c, x0c, p0c, tf_val)
-catch e
-    println(e)
-end
+```@repl main
+try # hide
+fc(t0c, x0c, p0c, tf_val)
+catch e # hide
+showerror(IOContext(stdout, :color => false), e) # hide
+end # hide
 ```
 
 The mirror image is also enforced: passing `variable=` to a flow built from a `Fixed` problem

--- a/docs/src/flows/shooting.md
+++ b/docs/src/flows/shooting.md
@@ -107,13 +107,13 @@ A nonlinear solver explores guesses that don't correspond to a real solution —
 can make the flow's integration blow up. The default behaviour is to throw, which would abort
 the whole solve on the first bad guess:
 
-```@example main
-f_blowup = Flow(VectorField(x -> x^2))   # ẋ = x², genuinely diverges before t=1
-try
-    f_blowup(0.0, 10.0, 1.0)
-catch e
-    println(e)
-end
+```@repl main
+f_blowup = Flow(VectorField(x -> x^2));  # ẋ = x², diverges before t=1
+try # hide
+f_blowup(0.0, 10.0, 1.0)
+catch e # hide
+showerror(IOContext(stdout, :color => false), e) # hide
+end # hide
 ```
 
 `unsafe=true` returns whatever the integrator produced instead of throwing — garbage, but a

--- a/docs/src/flows/simulation.md
+++ b/docs/src/flows/simulation.md
@@ -37,13 +37,13 @@ state(traj_ol)(0.5)
     bare constant closure. `OpenLoop(() -> 1.0)` **builds without error** but fails on the
     first call, with a bare `MethodError` far from the actual mistake:
 
-    ```@example main
-    bad_law = OpenLoop(() -> 1.0)   # constructs fine — the trap
-    try
-        Flow(ControlledVectorField(fc), bad_law)(0.0, 1.0, 1.0)
-    catch e
-        println(e)
-    end
+    ```@repl main
+    bad_law = OpenLoop(() -> 1.0);   # constructs fine — the trap
+    try # hide
+    Flow(ControlledVectorField(fc), bad_law)(0.0, 1.0, 1.0)
+    catch e # hide
+    showerror(IOContext(stdout, :color => false), e) # hide
+    end # hide
     ```
 
     `OpenLoop(t -> 1.0)` above is the only correct spelling — there is no "autonomous open
@@ -60,12 +60,12 @@ f_cl(0.0, 1.0, 1.0)
 `DynClosedLoop` (the costate-carrying law kind) is rejected on a `ControlledVectorField` — it
 has no costate to carry:
 
-```@example main
-try
-    Flow(ControlledVectorField(fc), DynClosedLoop((x, p) -> x))
-catch e
-    println(e)
-end
+```@repl main
+try # hide
+Flow(ControlledVectorField(fc), DynClosedLoop((x, p) -> x))
+catch e # hide
+showerror(IOContext(stdout, :color => false), e) # hide
+end # hide
 ```
 
 ## From an optimal control problem
@@ -100,12 +100,12 @@ objective(traj_ocp)
 A flow built without an OCP has no cost to report — calling `objective` on it is a
 `PreconditionError`, not a silent `0.0` or `NaN`:
 
-```@example main
-try
-    objective(traj_ol)
-catch e
-    println(e)
-end
+```@repl main
+try # hide
+objective(traj_ol)
+catch e # hide
+showerror(IOContext(stdout, :color => false), e) # hide
+end # hide
 ```
 
 ## Inspecting the trajectory

--- a/docs/src/geometry/ad.md
+++ b/docs/src/geometry/ad.md
@@ -71,15 +71,15 @@ ZZV([1.0, 2.0])
 `is_autonomous=` and `is_variable=` work exactly as on [`Lift`](@ref); both operands must agree,
 or you get a `PreconditionError` naming both traits:
 
-```@example main
-Xa = VectorField(x -> [x[2], -x[1]])
-Xb = VectorField((t, x) -> [t + x[2], -x[1]]; is_autonomous=false)
+```@repl main
+Xa = VectorField(x -> [x[2], -x[1]]);
+Xb = VectorField((t, x) -> [t + x[2], -x[1]]; is_autonomous=false);
 
-try
-    ad(Xa, Xb)
-catch e
-    println(e)
-end
+try # hide
+ad(Xa, Xb)
+catch e # hide
+showerror(IOContext(stdout, :color => false), e) # hide
+end # hide
 ```
 
 ## Partial time derivative
@@ -108,24 +108,24 @@ typeof(dXV)
 | an `InPlace` operand | `NotImplemented` |
 | a `HamiltonianVectorField` passed to `ad` | `NotImplemented` |
 
-```@example main
-H = Hamiltonian((x, p) -> x[1] + p[1])
-try
-    ad(H, x -> x)
-catch e
-    println(e)
-end
+```@repl main
+H = Hamiltonian((x, p) -> x[1] + p[1]);
+try # hide
+ad(H, x -> x)
+catch e # hide
+showerror(IOContext(stdout, :color => false), e) # hide
+end # hide
 ```
 
 `ad` also refuses an `InPlace` operand:
 
-```@example main
-Xip = VectorField((dx, x) -> (dx .= [x[2], -x[1]]); is_inplace=true)
-try
-    ad(Xip, x -> x[1]^2)
-catch e
-    println(e)
-end
+```@repl main
+Xip = VectorField((dx, x) -> (dx .= [x[2], -x[1]]); is_inplace=true);
+try # hide
+ad(Xip, x -> x[1]^2)
+catch e # hide
+showerror(IOContext(stdout, :color => false), e) # hide
+end # hide
 ```
 
 ## Coming from v2.0

--- a/docs/src/geometry/lie-macro.md
+++ b/docs/src/geometry/lie-macro.md
@@ -94,12 +94,12 @@ them directly, but because `@Lie`'s expansion needs them in scope.
 The old `autonomous=`/`variable=` keywords are rejected at macro-expansion time, not silently
 accepted:
 
-```@example main
-try
-    eval(:(@Lie [$F1, $F2] autonomous=false))
-catch e
-    println(e)
-end
+```@repl main
+try # hide
+eval(:(@Lie [$F1, $F2] autonomous=false))
+catch e # hide
+showerror(IOContext(stdout, :color => false), e) # hide
+end # hide
 ```
 
 ## See also

--- a/docs/src/geometry/lift.md
+++ b/docs/src/geometry/lift.md
@@ -92,13 +92,13 @@ associated Hamiltonian system — see
 Lifting a `HamiltonianVectorField` doesn't work — it already lives on the cotangent space, so
 there's nothing left to lift:
 
-```@example main
-hvf = HamiltonianVectorField((x, p) -> (p, -x))
-try
-    Lift(hvf)
-catch e
-    println(e)
-end
+```@repl main
+hvf = HamiltonianVectorField((x, p) -> (p, -x));
+try # hide
+Lift(hvf)
+catch e # hide
+showerror(IOContext(stdout, :color => false), e) # hide
+end # hide
 ```
 
 The message talks about `ad`, not `Lift` — both operations share the same internal guard

--- a/docs/src/geometry/poisson.md
+++ b/docs/src/geometry/poisson.md
@@ -102,13 +102,13 @@ problem.
 
 `Poisson` is not defined on vector fields — lift them first:
 
-```@example main
-XV = VectorField(x -> [x[2], -x[1]])
-try
-    Poisson(XV, x -> x[1])
-catch e
-    println(e)
-end
+```@repl main
+XV = VectorField(x -> [x[2], -x[1]]);
+try # hide
+Poisson(XV, x -> x[1])
+catch e # hide
+showerror(IOContext(stdout, :color => false), e) # hide
+end # hide
 ```
 
 ## See also

--- a/docs/src/results/plot.md
+++ b/docs/src/results/plot.md
@@ -40,13 +40,13 @@ nothing # hide
 
 `plot` on a solution is an extension — nothing happens until `Plots` itself is loaded:
 
-```@example main
+```@repl main
 using Plots
-try
-    plot(sol)
-catch e
-    println(e)
-end
+try # hide
+plot(sol)
+catch e # hide
+showerror(IOContext(stdout, :color => false), e) # hide
+end # hide
 ```
 
 Wait — that's not a `Plots`-missing error, it's real: [CTModels.jl#392](https://github.com/control-toolbox/CTModels.jl/issues/392),

--- a/docs/src/results/save-load.md
+++ b/docs/src/results/save-load.md
@@ -97,12 +97,12 @@ Hint     Run: using JLD2
 Same pattern for `format=:JSON`, naming `JSON3` instead. An invalid `format` is caught before
 either extension is even needed:
 
-```@example main
-try
-    export_ocp_solution(sol; format=:XML)
-catch e
-    println(e)
-end
+```@repl main
+try # hide
+export_ocp_solution(sol; format=:XML)
+catch e # hide
+showerror(IOContext(stdout, :color => false), e) # hide
+end # hide
 ```
 
 ## Filenames have no extension of their own

--- a/docs/src/results/solution.md
+++ b/docs/src/results/solution.md
@@ -100,12 +100,12 @@ iterations(sol), constraints_violation(sol)
     method (it resolves to `Base.success`, a process-exit-status function). Calling it on a
     `Solution` now throws a migration-pointing error:
 
-    ```@example main
-    try
-        success(sol)
-    catch e
-        println(e)
-    end
+    ```@repl main
+    try # hide
+    success(sol)
+    catch e # hide
+    showerror(IOContext(stdout, :color => false), e) # hide
+    end # hide
     ```
 
     See [Migration](@ref migration) for the full list of renamed spellings.

--- a/docs/src/solve/choosing-a-method.md
+++ b/docs/src/solve/choosing-a-method.md
@@ -81,12 +81,12 @@ Two tokens from the *same* family never both fit one method — `:adnlp` and `:e
 be true of one quadruplet — so this raises `AmbiguousDescription` rather than silently picking
 one:
 
-```@example main
-try
-    solve(ocp, :adnlp, :exa; display=false)
-catch e
-    println(e)
-end
+```@repl main
+try # hide
+solve(ocp, :adnlp, :exa; display=false)
+catch e # hide
+showerror(IOContext(stdout, :color => false), e) # hide
+end # hide
 ```
 
 The exception lists every candidate whose tokens are a superset of what matched, so you can see

--- a/docs/src/solve/explicit-mode.md
+++ b/docs/src/solve/explicit-mode.md
@@ -101,12 +101,17 @@ nothing # hide
 A flat option keyword handed to `solve` itself, rather than to the component constructor, is
 rejected — even one a completed default component would otherwise recognize:
 
-```@example explicit
-try
-    solve(ocp; discretizer=OptimalControl.Collocation(), backend=:generic, display=false)
-catch e
-    println(e)
-end
+```@repl explicit
+try # hide
+solve(
+    ocp;
+    discretizer=OptimalControl.Collocation(),
+    backend=:generic,
+    display=false,
+)
+catch e # hide
+showerror(IOContext(stdout, :color => false), e) # hide
+end # hide
 ```
 
 The error names the strategy that owns the option and tells you exactly how to fix it:
@@ -118,12 +123,16 @@ a concrete instance.
 
 Symbolic tokens and typed components can't appear in the same call:
 
-```@example explicit
-try
-    solve(ocp, :adnlp, :ipopt; discretizer=OptimalControl.Collocation(), display=false)
-catch e
-    println(e)
-end
+```@repl explicit
+try # hide
+solve(
+    ocp, :adnlp, :ipopt;
+    discretizer=OptimalControl.Collocation(),
+    display=false,
+)
+catch e # hide
+showerror(IOContext(stdout, :color => false), e) # hide
+end # hide
 ```
 
 Pick one: `solve(ocp, :collocation, :adnlp, :ipopt; options...)` or

--- a/docs/src/solve/initial-guess.md
+++ b/docs/src/solve/initial-guess.md
@@ -316,12 +316,17 @@ variable accept an initial guess.
 `init` is an alias for `initial_guess`; use whichever reads better. **In explicit mode**,
 supplying both at once is rejected cleanly:
 
-```@example main
-try
-    solve(ocp1; discretizer=OptimalControl.Collocation(), init=1, initial_guess=2, display=false)
-catch e
-    println(e)
-end
+```@repl main
+try # hide
+solve(
+    ocp1;
+    discretizer=OptimalControl.Collocation(),
+    init=1, initial_guess=2,
+    display=false,
+)
+catch e # hide
+showerror(IOContext(stdout, :color => false), e) # hide
+end # hide
 ```
 
 !!! warning "Same conflict, worse message in descriptive mode"
@@ -332,12 +337,12 @@ end
     *unrecognized solver option* rather than as a conflicting alias — a much more confusing
     message for the same mistake:
 
-    ```@example main
-    try
-        solve(ocp1; init=1, initial_guess=2, display=false)
-    catch e
-        println(e)
-    end
+    ```@repl main
+    try # hide
+    solve(ocp1; init=1, initial_guess=2, display=false)
+    catch e # hide
+    showerror(IOContext(stdout, :color => false), e) # hide
+    end # hide
     ```
 
     This is a real inconsistency between the two code paths, not intentional behavior — don't

--- a/docs/src/solve/options.md
+++ b/docs/src/solve/options.md
@@ -45,12 +45,12 @@ nothing # hide
 
 An option nobody recognizes is rejected with a "did you mean" suggestion:
 
-```@example advanced
-try
-    solve(ocp, :ipopt; max_iter=100, mumps_print_level=1, display=false)
-catch e
-    println(e)
-end
+```@repl advanced
+try # hide
+solve(ocp, :ipopt; max_iter=100, mumps_print_level=1, display=false)
+catch e # hide
+showerror(IOContext(stdout, :color => false), e) # hide
+end # hide
 ```
 
 ## Ambiguous options

--- a/docs/src/solve/overview.md
+++ b/docs/src/solve/overview.md
@@ -86,13 +86,13 @@ value `isa` `AbstractDiscretizer`, `AbstractNLPModeler`, or `AbstractNLPSolver` 
 into explicit mode, no matter what that keyword is called. Mixing a typed component with a
 non-empty symbolic description is rejected outright:
 
-```@example main
+```@repl main
 using MadNLP
-try
-    solve(ocp, :collocation; solver=OptimalControl.MadNLP())
-catch e
-    println(e)
-end
+try # hide
+solve(ocp, :collocation; solver=OptimalControl.MadNLP())
+catch e # hide
+showerror(IOContext(stdout, :color => false), e) # hide
+end # hide
 ```
 
 ## When it fails


### PR DESCRIPTION
## Why

`Handbook/VITEPRESS-DOC.md:241-260` gives the rule and its reason. DocumenterVitepress renders
`@example` output in an ` ```ansi ` fence, where Shiki processes the colours, but `@repl` output
in a ` ```julia ` fence, where ANSI escapes come out raw. Hence the prescribed shape for
exceptions — `@repl` + `try/catch # hide` +
`showerror(IOContext(stdout, :color => false), e) # hide` — which produces plain text that
renders cleanly. Upstream limitation, tracked as LuxDL/DocumenterVitepress.jl#321.

Adoption across the ecosystem:

| Package | `showerror` uses | following the convention |
| --- | --: | --: |
| CTBase | 24 | 24 |
| CTSolvers | 13 | 13 |
| CTModels | 10 | 10 |
| CTFlows | 9 | 0 |
| **OptimalControl** | **0** | **0** |

Every exception in this package went through `println(e)` — 30 of them — which prints the struct
dump rather than the formatted block the ecosystem's exceptions define. What a reader got:

```
CTBase.Exceptions.AmbiguousDescription("cannot find matching description", (:adnlp, :exa), ["(:collocation, :adnlp, :ipopt, :cpu)", …], "Try one of the closest matches:", "description completion", "no complete match")
```

What the convention gives, from the built page in this branch:

```
julia> Xa = VectorField(x -> [x[2], -x[1]]);

julia> Xb = VectorField((t, x) -> [t + x[2], -x[1]]; is_autonomous=false);

julia> ad(Xa, Xb)
PreconditionError → top-level scope, REPL[3]:2
│
│  ad: TD/VD mismatch between X and Y
│
│  Reason   X: Autonomous/Fixed ≠ Y: NonAutonomous/Fixed — both arguments must share …
│
│  Context  ad on AbstractVectorField
│  Hint     Ensure both vector fields have the same time and variable dependence traits
└─
```

The `try`/`catch`/`showerror`/`end` scaffolding is invisible; the failing call gets a plain
`julia>` prompt.

## What changes

29 blocks across 18 files. Three choices worth stating:

**Setup lines get a trailing `;`.** Under `@repl` every expression displays its value, so a
`VectorField` — or a whole `@def` model — would flood the output before the error appeared. Seven
blocks need it. The multi-line case renders correctly, with REPL continuation indentation:

```
julia> ocp_cf = @def begin
           t ∈ [t0, tf], time
           …
       end;

julia> Flow(ocp_cf; constraint=(x, u) -> 1.0, multiplier=(x, p) -> 1.0)
PreconditionError → top-level scope, REPL[2]:2
…
```

**No trailing `# Error:` comment**, though CTBase uses one. Its blocks sit inside docstrings with
no surrounding prose; here every one of the 29 already has a lead-in sentence saying what fails.
The comment also only fitted inside the 75-character limit on about half of them, and appearing
on half the blocks would read as arbitrary rather than as a convention.

**Five call lines are wrapped.** They were already over 75 characters before this change — but
they are lines this PR moves, and leaving them would be sloppy. Small down-payment on the
line-width backlog.

## The thirtieth block

`solve/choosing-a-method.md`'s Gauss-Legendre demonstration stays on `println(e)`, deliberately.
CTParser throws a bare `String` there rather than a typed exception
(control-toolbox/CTParser.jl#322), so `showerror` falls back to `show` and prints the message
**in quotes**. The block also wraps its call in a logger suppression
(control-toolbox/CTParser.jl#323) that does not suit a `julia>` echo.

It is the one exception demonstration in the site the convention cannot accommodate, and the
reason is precisely that the exception is not typed. It converts itself once CTParser is fixed.

## Verification

`julia --project=docs docs/make.jl`: **789 log lines, 12 errors, 186 warnings, 166 unresolved
`@ref`, zero failing block**, exit 0 — identical to the baseline. Every converted block was read
in the built HTML, including the two hard cases (inside an admonition, and with a multi-line
`@def` as setup), not merely counted in the log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)