### PR TITLE
docs(api): document the six internals pulled in undocumented

### DIFF
--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -21,6 +21,16 @@ using LinearAlgebra: ⋅
 
 export Lie, ⋅, HamiltonianLift
 
+"""
+$(TYPEDSIGNATURES)
+
+Build the [`CTBase.Exceptions.PreconditionError`](@extref) every shim in this file
+throws.
+
+One constructor for all of them, so the wording stays identical: what was removed,
+that it went in v2.1.0-beta, and what to write instead. See
+[Migrating to v2.1](@ref migration) for the full table.
+"""
 function _deprecated(old, new, ctx = nothing)
     return PreconditionError(
         "`$old` is deprecated";

--- a/src/helpers/explicit_validation.jl
+++ b/src/helpers/explicit_validation.jl
@@ -16,6 +16,16 @@ function _extract_explicit_component_kwargs(kwargs::Base.Pairs)
     return Base.pairs(remaining)
 end
 
+"""
+$(TYPEDSIGNATURES)
+
+Whether `value` is a strategy instance rather than a plain option value.
+
+A keyword whose value `isa` one of the family abstract types in `families` is a
+*component* — it names which strategy to use — not an option to route. This is the
+test that puts `solve` into explicit mode, so it is deliberately structural: any
+third-party strategy subtyping one of the families is recognised without registration.
+"""
 function _is_explicit_component(value, families=_descriptive_families())
     return any(T -> value isa T, values(families))
 end
@@ -64,6 +74,16 @@ function _validate_explicit_options(kwargs, components::NamedTuple)
     return nothing
 end
 
+"""
+$(TYPEDSIGNATURES)
+
+Reject an option that belongs to exactly one of the explicitly given strategies.
+
+In explicit mode the caller has already constructed the strategy, so the option
+belongs in that constructor — routing it through `solve` would silently override a
+choice the caller made by hand. Always throws
+[`CTBase.Exceptions.IncorrectArgument`](@extref), naming the strategy to configure.
+"""
 function _throw_strategy_explicit_option(option, owner, components::NamedTuple)
     strategy = components[owner]
     strategy_name = nameof(typeof(strategy))
@@ -78,6 +98,16 @@ function _throw_strategy_explicit_option(option, owner, components::NamedTuple)
     )
 end
 
+"""
+$(TYPEDSIGNATURES)
+
+Reject an option declared by several of the explicitly given strategies.
+
+`route_to` disambiguates in descriptive mode, but it has no counterpart here: the
+strategies are already built, so the caller sets the option on whichever one they
+meant. Always throws [`CTBase.Exceptions.IncorrectArgument`](@extref), listing every
+claimant.
+"""
 function _throw_ambiguous_explicit_option(option, owners)
     owner_names = join(string.(owners), ", ")
     return throw(
@@ -91,6 +121,15 @@ function _throw_ambiguous_explicit_option(option, owners)
     )
 end
 
+"""
+$(TYPEDSIGNATURES)
+
+Reject an option no explicitly given strategy claims, and that is not a solve action
+option either.
+
+Always throws [`CTBase.Exceptions.IncorrectArgument`](@extref), listing the action
+options `solve` does accept in explicit mode.
+"""
 function _throw_unknown_explicit_option(option)
     action_options = join(_explicit_option_names(), ", ")
     return throw(

--- a/src/helpers/print.jl
+++ b/src/helpers/print.jl
@@ -320,6 +320,10 @@ from "the strategy never implemented the contract at all" (`parameter(T)` threw
 with it.
 """
 struct _ParameterNotImplemented end
+
+"""
+The single [`_ParameterNotImplemented`](@ref) instance, used as the sentinel value.
+"""
 const _PARAMETER_NOT_IMPLEMENTED = _ParameterNotImplemented()
 
 """


### PR DESCRIPTION
## What this changes

Six private helpers reached `api/internals.md` with no docstring, each producing a
"No documentation found … Skipping from API reference" warning and a gap in the published page:
`_deprecated`, `_is_explicit_component`, `_PARAMETER_NOT_IMPLEMENTED`, and the three
`_throw_*_explicit_option` helpers.

Build goes from **186 warnings to 180**. Nothing else moves.

## What this does *not* change, and why

This started as "fix the 166 unresolved `@ref`". It turns out **none of them can be fixed in this
repository**, and the diagnosis is worth recording in full because the obvious answers are all
wrong.

**It is not the missing `InterLinks` inventories.** Those govern `@extref`; these are `@ref`.
The Handbook (`philosophy/documentation.md:170-187`) also describes a sibling's local inventory
as a *fallback* whose absence in CI is expected.

**It is not sibling docstrings written with the wrong macro.** Checked in the sibling sources:

| | local `main` |
| --- | --- |
| CTBase | 0 `@ref`, 1028 `@extref` |
| CTLie | 0 `@ref`, 118 `@extref` |
| CTModels | 0 `@ref`, 811 `@extref` |
| CTFlows | 15 `@ref`, 1178 `@extref` |
| CTSolvers | 0 `@ref`, 128 `@extref` |

They are migrated. **But the docs environment resolves the siblings from the registry, not from
the working copies**, and the released versions are the exact inverse:

| | installed (registry) |
| --- | --- |
| CTBase | **1028 `@ref`**, 0 `@extref` |
| CTLie | **118 `@ref`**, 0 |
| CTModels | **804 `@ref`**, 3 |
| CTFlows | **880 `@ref`**, 311 |
| CTSolvers | **91 `@ref`**, 35 |

Confirmed symbol by symbol: `CTFlows.Systems.HamiltonianSystem` appears 16 times written
`](@ref)` in the installed CTFlows and 16 times written `](@extref)` in the working copy.

So the 166 are docstrings from released sibling versions that predate the `@ref` → `@extref`
migration, transcluded into our generated API reference. **The migration is done everywhere and
released nowhere.** The same goes for the un-expanded `@example` block on `api/modelling.md` — it
comes from an installed CTParser docstring.

## The lock

Pulling the migrated docstrings means resolving newer siblings, which does not resolve:

```
Unsatisfiable requirements detected for package CTBase [54762871]:
 ├─restricted to versions 0.29 by an explicit requirement
 └─restricted by compatibility requirements with CTParser [32681960]
   to versions: [0.14.0 - 0.18.15, 0.25.0, 0.27.0 - 0.28.9] — no versions left
```

CTParser 0.8.17 caps CTBase at 0.28.9. Until CTParser raises that bound and the siblings release
their migration, the counter cannot move from here.

**Consequence for CI:** tightening `warnonly` is not blocked by documentation work but by a
release cycle. Worth considering a partial tightening that excludes `:cross_references`, so a
broken `@example` or a missing docstring becomes blocking now, without waiting on upstream.

## Two notes from the process

`docs/src/assets/Manifest.toml` is tracked (deliberately — it is the downloadable environment
snapshot). `Pkg.develop` with an absolute path rewrites its `path = ".."` entry to a developer's
home directory. Caught before committing here, but it is a live hazard for anyone re-resolving
the docs environment.

The `api_reference.jl` staleness guard earns its keep. A mis-resolved environment — the released
OptimalControl instead of the working copy — made it fail the build outright, naming the ten
symbols that were missing. It is a real check, independent of `warnonly`.

## Verification

`julia --project=docs docs/make.jl`: 774 log lines, 12 errors, **180 warnings**, 166 unresolved
`@ref`, zero failing `@example` block, exit 0. The six "No documentation found" warnings are gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)