### PR TITLE
docs: retire the workarounds the upgrade made obsolete, fix the GPU prerequisites

### DIFF
--- a/docs/src/getting-started/first-problem.md
+++ b/docs/src/getting-started/first-problem.md
@@ -49,12 +49,8 @@ nothing # hide
 
 ```@example main
 using Plots
-plot(sol; layout=:group)
+plot(sol)
 ```
-
-(`layout=:group` sidesteps a known upstream bug in the default layout,
-[CTModels.jl#392](https://github.com/control-toolbox/CTModels.jl/issues/392) — see
-[Plotting](@ref results-plot) for the full story.)
 
 ```@example main
 objective(sol), iterations(sol), successful(sol)

--- a/docs/src/getting-started/installation.md
+++ b/docs/src/getting-started/installation.md
@@ -109,15 +109,25 @@ See [Save & load](@ref results-save-load).
 ## Optional: GPU
 
 ```julia
-using ExaModels
 using MadNLPGPU
 using CUDA
+using CUDSS
 ```
 
-NVIDIA GPUs only; the problem's dynamics must be written coordinatewise. Missing any of the
-three raises the same `ExtensionError` as above, naming whichever is missing first. See
-[GPU](@ref solve-gpu) for the constraints and check `CUDA.functional()` before assuming a
-`:gpu` solve will actually run on the device.
+NVIDIA GPUs only; the problem's dynamics must be written coordinatewise.
+
+All three are required together — they are what arms the `CTSolversMadNLPGPU` extension. Older
+guides list only the first two, because up to MadNLPGPU 0.8 `CUDSS` came in as a hard
+dependency; from 0.9 it is weak and has to be loaded explicitly.
+
+Unlike the optional pieces above, a missing one is **not** reported accurately: the
+`ExtensionError` always names `MadNLPGPU`, even when the package actually absent is `CUDSS`
+([CTSolvers#216](https://github.com/control-toolbox/CTSolvers.jl/issues/216)). If you loaded
+`MadNLPGPU` and are told to load `MadNLPGPU`, the answer is `using CUDSS`.
+
+`ExaModels` is not in the list on purpose: it ships as a dependency of OptimalControl, so
+`:exa` works without importing it. See [GPU](@ref solve-gpu) for the constraints, and check
+`CUDA.functional()` before assuming a `:gpu` solve will actually run on the device.
 
 ## Checking your setup
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -35,7 +35,7 @@ ocp = @def begin
 end
 
 sol = solve(ocp)
-plot(sol; layout=:group)
+plot(sol)
 ```
 
 - For more details, see the [energy minimisation example](@ref examples-double-integrator-energy).  

--- a/docs/src/results/plot.md
+++ b/docs/src/results/plot.md
@@ -38,29 +38,14 @@ sol = solve(ocp; display=false)
 nothing # hide
 ```
 
-`plot` on a solution is an extension — nothing happens until `Plots` itself is loaded:
-
-```@repl main
-using Plots
-try # hide
-plot(sol)
-catch e # hide
-showerror(IOContext(stdout, :color => false), e) # hide
-end # hide
-```
-
-Wait — that's not a `Plots`-missing error, it's real: [CTModels.jl#392](https://github.com/control-toolbox/CTModels.jl/issues/392),
-a genuine upstream bug hit while writing this page. A bare `plot(sol)` currently fails whenever
-the default subplot selection includes the costate column under the default `:split` layout —
-which is nearly always. **Explicit selectors or `layout=:group` both avoid it**:
+`plot` on a solution is an extension — nothing is drawn until `Plots` itself is loaded:
 
 ```@example main
-plot(sol, :state, :costate, :control)
+using Plots
+plot(sol)
 ```
 
-Every example below uses one of those two forms for that reason, not by preference. Loading
-`Plots` before `plot(sol)` at all — the *actual* extension gate — throws a clean
-`ExtensionError` instead:
+Without `Plots` in the session the call throws a clean `ExtensionError` instead:
 
 ```julia
 julia> using OptimalControl
@@ -122,8 +107,7 @@ plot(sol, :state, :control)
 ## Layout
 
 `layout=:group` puts each family (state, costate, control) in one subplot instead of one per
-component — and, as shown above, is one of the two ways to sidestep CTModels.jl#392 on a bare
-call:
+component:
 
 ```@example main
 plot(sol; layout=:group)

--- a/docs/src/solve/choosing-a-method.md
+++ b/docs/src/solve/choosing-a-method.md
@@ -97,13 +97,17 @@ what's close.
 | Solver | Load |
 | --- | --- |
 | `:ipopt` | `using NLPModelsIpopt` |
-| `:madnlp` | `using MadNLP` (CPU) or `using MadNLPGPU` (GPU) |
+| `:madnlp` | `using MadNLP` (CPU) |
 | `:uno` | `using UnoSolver` |
 | `:madncl` | `using MadNCL` and `using MadNLP` (both) |
 | `:knitro` | `using NLPModelsKnitro` (commercial licence required) |
+| either on `:gpu` | `using MadNLPGPU`, `using CUDA` **and** `using CUDSS` — all three |
 
 Solving without the matching package loaded raises an `ExtensionError` naming exactly which
-`using` statement to add.
+`using` statement to add — with one exception. On the `:gpu` row the error always names
+`MadNLPGPU`, even when the package actually missing is `CUDSS`
+([CTSolvers#216](https://github.com/control-toolbox/CTSolvers.jl/issues/216)); see
+[Solving on GPU](@ref solve-gpu).
 
 ## Inspecting a strategy
 
@@ -154,18 +158,18 @@ Every cell above was checked by solving with that scheme. Two of the results nee
     `:euler_forward` is rejected where `:euler` is accepted, though under `:adnlp` the two name
     the same scheme. Confirmed live:
 
-    ```@example main
-    using Logging
-    # ExaModels warns about a deprecated `ExaCore()` call on every model it
-    # builds; silenced here so the scheme error is the only output.
-    try
-        with_logger(NullLogger()) do
-            solve(ocp, :exa; scheme=:gauss_legendre_2, display=false)
-        end
-    catch e
-        println(e)
-    end
+    ```@repl main
+    try # hide
+    solve(ocp, :exa; scheme=:gauss_legendre_2, display=false)
+    catch e # hide
+    showerror(IOContext(stdout, :color => false), e) # hide
+    end # hide
     ```
+
+    The `Line 6:` prefix is emitted by the parser, not by the error. It reports the generated
+    line that was running when the exception escaped — here the dynamics equation, which is
+    correct and has nothing to do with the scheme. See
+    [CTParser#338](https://github.com/control-toolbox/CTParser.jl/issues/338).
 
 !!! warning "`:variable` is advertised but does not run"
 

--- a/docs/src/solve/gpu.md
+++ b/docs/src/solve/gpu.md
@@ -21,12 +21,33 @@ GPU support runs through [ExaModels.jl](https://exanauts.github.io/ExaModels.jl/
 
 ```julia
 using OptimalControl
-using ExaModels
 using MadNLPGPU
 using CUDA
+using CUDSS
 ```
 
 Check `CUDA.functional()` before assuming a `:gpu` solve will actually run on the device.
+
+!!! warning "All three — and `CUDSS` is the one you will forget"
+
+    The `CTSolversMadNLPGPU` extension is armed by `MadNLPGPU`, `CUDA` **and** `CUDSS`
+    together. Load only the first two — the pair every GPU tutorial shows — and the extension
+    does not load, so the GPU solver strategies are never registered.
+
+    It used to work by accident. Up to MadNLPGPU 0.8, `CUDSS` was a hard dependency, so
+    `using MadNLPGPU` pulled it in and the third trigger was satisfied without anyone asking.
+    From 0.9 onward it is a weak dependency and you must load it yourself.
+
+    You do get an error, but it points the wrong way. It reports `Missing MadNLPGPU` and
+    suggests `using MadNLPGPU`, which you already did; the package actually absent is `CUDSS`.
+    See [CTSolvers#216](https://github.com/control-toolbox/CTSolvers.jl/issues/216).
+
+`ExaModels` needs no `using` of its own. It is a dependency of OptimalControl, so the module is
+already bound after `using OptimalControl` and `:exa` works without it. Importing it explicitly
+also brings its `objective` and `constraint` into scope, both of which collide with the
+accessors of the same name — see
+[#882](https://github.com/control-toolbox/OptimalControl.jl/issues/882). If you do need
+ExaModels' own API, import it qualified: `using ExaModels: ExaModels`.
 
 ## The problem must be coordinatewise
 


### PR DESCRIPTION
Phases B and C of [`.reports/compat-upgrade-2026-08.md`](https://github.com/control-toolbox/OptimalControl.jl/blob/main/.reports/compat-upgrade-2026-08.md), on top of #884.

Six pages. Every removal was **verified against the new versions before the prose came out**,
rather than taken from the upstream changelogs:

| checked | result |
| --- | --- |
| `plot(sol)`, default layout | OK — CTModels#392 fixed |
| scheme × modeler matrix | unchanged, all 20 cells re-solved |
| `times(sol) == time_grid(sol)` | `true`, `Vector{Float64}` |
| `:exa` solve end-to-end | `objective = 6.0000960`, the analytic value |
| `final_time(sol)`, free `tf` | `1.99999999` — CTModels#402 fixed |

## GPU prerequisites

`CUDSS` was missing from every list on the site. The `CTSolversMadNLPGPU` trigger is
`MadNLPGPU` + `CUDA` + `CUDSS`, all three.

**It used to work by accident.** Up to MadNLPGPU 0.8, `CUDSS` was a hard dependency, so
`using MadNLPGPU` pulled it in and the third trigger was satisfied without anyone asking. From
0.9 it is a weak dependency. Our bound is `MadNLPGPU = "0.8, 0.10"`, so both behaviours are in
range — and a free resolve picks 0.10 today.

The failure is not silent, it is worse: the `ExtensionError` reports `Missing MadNLPGPU` and
tells you to run `using MadNLPGPU`, which you already did. The package actually absent is
`CUDSS` ([CTSolvers#216](https://github.com/control-toolbox/CTSolvers.jl/issues/216)).

`choosing-a-method.md` claimed the error "names exactly which `using` statement to add". True
everywhere except the one row where it matters most; it now carries the exception, and the
table has a `:gpu` row.

**`using ExaModels` removed** from `gpu.md` and `installation.md` (#882). It is unnecessary —
ExaModels is a hard dependency of OptimalControl, and `:exa` solves without it — and actively
harmful: ExaModels 0.12 newly exports `objective` and `constraint`, both colliding with our
accessors of the same name. The reader who copies the prerequisites and then calls
`objective(sol)` gets `UndefVarError`.

## Workarounds retired

**The last `println(e)`.** `choosing-a-method.md` had the site's only remaining one, wrapped in
`with_logger(NullLogger())` to swallow an `ExaCore` deprecation warning. CTParser 0.9 fixed both
(#322 typed the throw, #323 removed the warning), so the block is now the Handbook form. The
site is at **zero** `println(e)` and **zero** `with_logger`.

**The plot workarounds.** `index.md` and `first-problem.md` carried `layout=:group` purely to
dodge CTModels#392, plus a parenthetical sending a beginner to an upstream issue tracker in
their first sixty lines. Both gone; the default layout works.

`plot.md` had a whole block *demonstrating* #392 as a live failure, and the caveat "every
example below uses one of those two forms for that reason, not by preference". A bare
`plot(sol)` now renders — confirmed in the built page. The five remaining `layout=:group` teach
the option and stay.

No page on the site mentions #392 any more.

## One thing left visible on purpose

The parser prints a line ahead of the scheme error:

```
Line 6: (∂(q))(t) == v(t)
IncorrectArgument → macro expansion
│  unknown numerical scheme
```

Line 6 is a correct dynamics equation with nothing to do with the scheme —
`onepass.jl` wraps every generated line and attributes whatever escapes it. Reported as
[CTParser#338](https://github.com/control-toolbox/CTParser.jl/issues/338). Rather than hide it,
the page now has a sentence saying what it is.

## Build

Clean. And the headline number for the next phase:

```
unresolved @ref:  166  →  6
```

The six left are all in the generated `src/api/solving.md`: `PostconditionSpecifier`,
`DOCPCache` (×2), `which`, `@which`, `methodswith`. The collapse confirms the diagnosis — the
166 were sibling docstrings from releases predating the `@ref` → `@extref` migration, and the
new releases carry it.

⚠️ **Caveat on that build.** It ran in a git worktree, where `make.jl` looks for sibling
inventories at `@__DIR__/../../CTBase/...` — which resolves to `worktrees/CTBase` and does not
exist. All seven siblings fell back to the network. The six remaining `@extref` errors
(`CTModels.Solution`, `Plots.plot(::CTModels.Solution)`, `CTBase.Strategies.parameter`) may be
an artefact of stale published inventories rather than real breakage, and want re-measuring from
a normal clone before anyone acts on them. Same reason the inventory-failure count reads 10 of
12 here and 5 of 12 from the main repository.

## Not in this PR

- `times(sol)` on `results/solution.md` — that page is the separate free-time PR.
- `scheme=:variable` still raises `UndefVarError`; `CTDirect.jl:63` still has
  `#include("ode/variable.jl")` on 1.1.1-beta ([CTDirect#624](https://github.com/control-toolbox/CTDirect.jl/issues/624)).
  The warning box and the ✗/✗ row stay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
