### PR TITLE
fix(#882): stop recommending `using ExaModels`, add export-collision canary

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -1,3 +1,24 @@
+# Non-breaking notes
+
+## Non-breaking note (2.2.0-beta)
+
+- **`using ExaModels` now clashes with OptimalControl.** ExaModels 0.12 added `objective` and `constraint` to its export list (oracle builders); OptimalControl exports both names as accessors. Loading ExaModels unqualified next to OptimalControl makes `objective(sol)` / `constraint(ocp, :label)` throw `UndefVarError` — Julia refuses to resolve the ambiguous binding.
+
+  **No migration required for the common case.** The `:exa` modeler needs no `using ExaModels`: the module is bound through `using OptimalControl` and `solve(ocp, :exa)` works as-is. Only import ExaModels if you genuinely need its own API, and then import it qualified:
+
+  ```julia
+  # Before — shadows the accessors
+  using ExaModels
+
+  # After
+  using ExaModels: ExaModels
+  ExaModels.some_function(...)
+  ```
+
+  **No breaking change to OptimalControl's API**: `objective` / `constraint` are unchanged. See [#882](https://github.com/control-toolbox/OptimalControl.jl/issues/882), and the same fix one layer down in [CTParser#230](https://github.com/control-toolbox/CTParser.jl/issues/230).
+
+---
+
 # Breaking Changes: v2.0 → v2.1.0-beta
 
 This section describes the breaking changes when migrating from **OptimalControl.jl v2.0.5-beta** to **v2.1.0-beta**. For the v1.x → v2.0 migration, see [the section below](#breaking-changes-v1x--v20).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,37 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
-## [2.1.0-beta] — unreleased
+## [2.2.0-beta] — 2026-08-28
+
+Dependency realignment onto the released control-toolbox ecosystem and a full documentation-site rewrite. No breaking change to OptimalControl's own API; one near-breaking upstream note — see [BREAKING.md](BREAKING.md).
+
+### Dependencies
+
+- **Realigned on the released ecosystem** — every sibling resolves from the General registry with no `Pkg.develop`: CTBase `0.28`→`0.29`, CTModels `0.15`→`0.18`, CTSolvers `0.4`→`0.5`, CTFlows `0.16`→`0.17`, CTParser `0.8`→`0.9`, CTLie `0.1`→`0.2`; CTDirect stays pinned to `1` (the major alone, per the pinning-granularity rule)
+
+- **ExaModels `0.11`→`0.12`** — not optional: CTParser 0.9 emits `add_var` / `add_con` / `add_obj`, which do not exist in ExaModels 0.11, so every `:exa` solve fails at run time on the older version
+
+- `docs/Project.toml` and `docs/src/assets/{Project,Manifest}.toml` mirror the root environment exactly
+
+### Fixed
+
+- **`using ExaModels` alongside `using OptimalControl` is no longer suggested anywhere.** ExaModels 0.12 newly exports `objective` and `constraint`, both of which OptimalControl also exports; importing ExaModels unqualified shadows the accessors and the next `objective(sol)` throws `UndefVarError`. The `:exa` modeler needs no `using ExaModels` at all — the module is already bound through `using OptimalControl`. `docs/src/solve/gpu.md` and `docs/src/getting-started/installation.md` dropped the bare import and now state that `:exa` needs no extra package. See [#882](https://github.com/control-toolbox/OptimalControl.jl/issues/882)
+
+### Testing
+
+- **Export-collision canary**: a regression test pins `intersect(names(ExaModels), names(OptimalControl))` to its known genuine-clash set `[:constraint, :objective]`, so the next colliding upstream export lands as a red test rather than a user bug report
+
+### Documentation
+
+- The documentation site was rewritten onto a new sitemap (getting started, modelling, solve, results, flows, geometry, an examples gallery, and a thematic API reference) and a v2.0 → v2.1 migration page added. The retired v2.0 manuals are kept under `docs/attic/`
+
+### Compatibility
+
+- **No breaking changes to OptimalControl's own public API.** One near-breaking upstream change: `using ExaModels` now collides with the `objective` / `constraint` accessors. See [BREAKING.md](BREAKING.md).
+
+---
+
+## [2.1.0-beta] — 2026-07-30
 
 Dependency upgrade onto the restructured control-toolbox stack, CTLie integration, and a substantial test rework. See [BREAKING.md](BREAKING.md) for the migration guide.
 
@@ -685,6 +715,8 @@ multiple versions.
   keyword arguments to any OptimalControl function, rename to the new keyword (see
   CTBase changelog for details).
 
+[2.2.0-beta]: https://github.com/control-toolbox/OptimalControl.jl/compare/v2.1.0-beta...v2.2.0-beta
+[2.1.0-beta]: https://github.com/control-toolbox/OptimalControl.jl/compare/v2.0.5-beta...v2.1.0-beta
 [2.0.5-beta]: https://github.com/control-toolbox/OptimalControl.jl/compare/v2.0.4...v2.0.5-beta
 [2.0.4]: https://github.com/control-toolbox/OptimalControl.jl/compare/v2.0.3...v2.0.4
 [2.0.3]: https://github.com/control-toolbox/OptimalControl.jl/compare/v2.0.2...v2.0.3

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "OptimalControl"
 uuid = "5f98b655-cc9a-415a-b60e-744165666948"
-version = "2.1.0-beta"
+version = "2.2.0-beta"
 authors = ["Olivier Cots <olivier.cots@toulouse-inp.fr>"]
 
 [deps]

--- a/test/suite/reexport/test_examodels.jl
+++ b/test/suite/reexport/test_examodels.jl
@@ -9,6 +9,7 @@ module TestExamodels
 
 using Test: Test
 using OptimalControl # using is mandatory since we test exported symbols
+using ExaModels: ExaModels # for names(ExaModels) in the export-collision canary
 
 const VERBOSE = isdefined(Main, :TestOptions) ? Main.TestOptions.VERBOSE : true
 const SHOWTIMING = isdefined(Main, :TestOptions) ? Main.TestOptions.SHOWTIMING : true
@@ -21,6 +22,28 @@ function test_examodels()
             Test.@test isdefined(OptimalControl, :ExaModels)
             Test.@test isdefined(CurrentModule, :ExaModels)
             Test.@test ExaModels isa Module
+        end
+
+        # --------------------------------------------------------------------
+        # Export-collision canary
+        # --------------------------------------------------------------------
+        # ExaModels 0.12 newly exports `objective` and `constraint` (oracle
+        # builders); OptimalControl exports both as accessors. A user who writes
+        # `using ExaModels` next to `using OptimalControl` then gets a bare
+        # `UndefVarError` on the next `objective(sol)` — Julia refuses to pick.
+        # The docs no longer tell anyone to import ExaModels (`:exa` needs no
+        # `using`), but this test turns the *next* upstream export that collides
+        # into a red test here rather than a user bug report. See issue #882.
+        Test.@testset "Export surface does not collide with OptimalControl" begin
+            shared = intersect(names(ExaModels), names(OptimalControl))
+            # keep only the genuine clashes: same name, different binding
+            # (`:ExaModels` itself is shared but resolves to the one module).
+            clash = sort!(
+                filter(
+                    s -> getglobal(ExaModels, s) !== getglobal(OptimalControl, s), shared
+                ),
+            )
+            Test.@test clash == [:constraint, :objective]
         end
     end
 end


### PR DESCRIPTION
Closes #882.

## Context

ExaModels 0.12 (pulled in by the #884 compat realignment) newly **exports** `objective` and `constraint` as oracle builders. OptimalControl exports both names as accessors. A user who writes a bare `using ExaModels` next to `using OptimalControl` — as two doc pages used to instruct — then gets `UndefVarError` on the next `objective(sol)`, the ambiguity Julia refuses to resolve.

The `using ExaModels` is not even needed: `src/imports/examodels.jl` already does `@reexport import ExaModels: ExaModels` and ExaModels is a hard `[deps]` entry, so `:exa` solves fine from `using OptimalControl` alone.

## What this PR does

The **documentation fix already landed** in `e22fc006` (`docs/src/solve/gpu.md`, `docs/src/getting-started/installation.md` no longer import ExaModels, and `gpu.md` explains the clash). What remained:

- **Regression canary** in `test/suite/reexport/test_examodels.jl`: pins `intersect(names(ExaModels), names(OptimalControl))`, filtered to genuine binding clashes, to `[:constraint, :objective]`. The next upstream export that collides now lands as a red test rather than a user bug report (issue's proposed fix #3). `:ExaModels` (same module object) is excluded automatically.
- **Changelog / breaking / version book-keeping**:
  - `[2.1.0-beta]` dated `2026-07-30` (it is the GitHub release, not "unreleased"); its dependency line is left as what that tag actually shipped.
  - New `[2.2.0-beta] — 2026-08-28` entry covering the #884 dependency realignment (CTBase 0.29 / CTModels 0.18 / CTSolvers 0.5 / CTFlows 0.17 / CTParser 0.9 / CTLie 0.2 / ExaModels 0.12) and the documentation-site rewrite.
  - `[2.1.0-beta]` / `[2.2.0-beta]` compare-links added to the footer.
  - `BREAKING.md`: `## Non-breaking note (2.2.0-beta)` — `using ExaModels` clash, `Before` / `After` block, cross-ref to CTParser#230.
  - `Project.toml`: `version = "2.2.0-beta"`.

## Not in scope

- No change to OptimalControl's own `objective` / `constraint` exports — owning them as thin wrappers (the disabled `src/imports/redefine.jl`) would not fix the clash: Julia still sees two packages exporting the name.
- `docs/make.jl:20` (`using ExaModels`, feeds `names(ExaModels)` only) left as-is.
- No upstream issue at exanauts/ExaModels.jl.

## Verification

- `suite/reexport` green — `test_examodels.jl` now 4 passes (was 3).
- Full suite: **2243 pass, 2 broken** (the deliberate `@test_skip` GPU sites, #883).
- Measured on the resolved environment, ExaModels 0.12.0: genuine clashes are exactly `[:constraint, :objective]`, matching the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)