### PR TITLE
docs: resolve the API reference @ref collisions, tighten warnonly (Phase D)

### DIFF
--- a/docs/api_reference.jl
+++ b/docs/api_reference.jl
@@ -71,7 +71,19 @@ const API_THEMES = [
     (
         id="solving", title="Solving",
         symbols=[
-            :solve, :methods, :discretize, :ocp_model, :nlp_model,
+            # `solve` and `methods` are bare-name qualified below (Pair form): both are
+            # generic functions the wider Julia/SciML ecosystem extends heavily, and a
+            # bare `:solve`/`:methods` pulls in every loaded package's docstring for the
+            # binding, not just ours (traced in the Phase D campaign report — e.g. Base's
+            # own `methods` docstring cross-references `which`/`@which`/`methodswith`,
+            # none of which resolve in this build).
+            :solve => "solve(::CTModels.AbstractModel, ::Symbol...)",
+            :solve => "solve(::CTModels.AbstractModel, ::CTModels.AbstractInitialGuess, " *
+                      "::CTSolvers.DOCP.AbstractDiscretizer, " *
+                      "::CTSolvers.Modelers.AbstractNLPModeler, " *
+                      "::CTSolvers.Solvers.AbstractNLPSolver)",
+            :methods => "methods()",
+            :discretize, :ocp_model, :nlp_model,
             :ocp_solution, :get_build_examodel,
         ],
     ),
@@ -194,7 +206,17 @@ const API_THEMES = [
 # below. Theme entries that are module-qualified (e.g. `CTModels.Solutions.variable`)
 # stand in for the bare exported name (`variable`) for that check — see
 # `_bare_name`.
+#
+# A theme entry can also be a `Pair` (e.g. `:solve => "solve(::CTModels.AbstractModel,
+# ::Symbol...)"`): the key is what the coverage check sees, the value is the exact
+# signature written into the `@docs` block. Needed whenever a bare name would pull in
+# a foreign package's docstring for the same generic function (`:solve` collides with
+# `CommonSolve.solve`, `:methods` with `Base.methods` — see docs/reports/99-api-coverage.md
+# and control-toolbox/OptimalControl.jl's Phase D campaign report for how this was found).
 _bare_name(s::Symbol) = Symbol(split(String(s), ".")[end])
+_bare_name(p::Pair) = _bare_name(first(p))
+_doc_entry(s::Symbol) = s
+_doc_entry(p::Pair) = last(p)
 
 const _COVERED_BARE_NAMES = let
     covered = Set{Symbol}()
@@ -277,7 +299,7 @@ function _generate_theme_page(docs_src, theme)
         end
         println(io, "```@docs; canonical=true")
         for s in theme.symbols
-            println(io, s)
+            println(io, _doc_entry(s))
         end
         println(io, "```")
     end

--- a/docs/inventories/ADNLPModels.toml
+++ b/docs/inventories/ADNLPModels.toml
@@ -1,0 +1,208 @@
+# DocInventory version 1
+project = "ADNLPModels"
+version = "0.8.13"
+
+[[jl.function]]
+name = "ADNLPModels.compute_jacobian_sparsity"
+uri = "reference/#$"
+
+[[jl.method]]
+name = "ADNLPModels.ADNLPModel-Union{Tuple{S}, Tuple{Any, S}} where S"
+uri = "reference/#ADNLPModels.ADNLPModel-Union%7BTuple%7BS%7D%2C%20Tuple%7BAny%2C%20S%7D%7D%20where%20S"
+[[jl.method]]
+name = "ADNLPModels.ADNLSModel-Union{Tuple{S}, Tuple{Any, S, Integer}} where S"
+uri = "reference/#ADNLPModels.ADNLSModel-Union%7BTuple%7BS%7D%2C%20Tuple%7BAny%2C%20S%2C%20Integer%7D%7D%20where%20S"
+[[jl.method]]
+name = "ADNLPModels.compute_hessian_sparsity-NTuple{4, Any}"
+uri = "reference/#ADNLPModels.compute_hessian_sparsity-NTuple%7B4%2C%20Any%7D"
+[[jl.method]]
+name = "ADNLPModels.get_F-Tuple{ADNLPModels.AbstractADNLSModel}"
+uri = "reference/#ADNLPModels.get_F-Tuple%7BADNLPModels.AbstractADNLSModel%7D"
+[[jl.method]]
+name = "ADNLPModels.get_adbackend-Tuple{Union{ADNLPModels.AbstractADNLPModel{T, S}, ADNLPModels.AbstractADNLSModel{T, S}} where {T, S}}"
+uri = "reference/#ADNLPModels.get_adbackend-Tuple%7BUnion%7BADNLPModels.AbstractADNLPModel%7BT%2C%20S%7D%2C%20ADNLPModels.AbstractADNLSModel%7BT%2C%20S%7D%7D%20where%20%7BT%2C%20S%7D%7D"
+[[jl.method]]
+name = "ADNLPModels.get_c-Tuple{Union{ADNLPModels.AbstractADNLPModel{T, S}, ADNLPModels.AbstractADNLSModel{T, S}} where {T, S}}"
+uri = "reference/#ADNLPModels.get_c-Tuple%7BUnion%7BADNLPModels.AbstractADNLPModel%7BT%2C%20S%7D%2C%20ADNLPModels.AbstractADNLSModel%7BT%2C%20S%7D%7D%20where%20%7BT%2C%20S%7D%7D"
+[[jl.method]]
+name = "ADNLPModels.get_default_backend-Tuple{Symbol, Vararg{Any}}"
+uri = "reference/#ADNLPModels.get_default_backend-Tuple%7BSymbol%2C%20Vararg%7BAny%7D%7D"
+[[jl.method]]
+name = "ADNLPModels.get_lag-Tuple{ADNLPModels.AbstractADNLPModel, ADNLPModels.ADBackend, Real}"
+uri = "reference/#ADNLPModels.get_lag-Tuple%7BADNLPModels.AbstractADNLPModel%2C%20ADNLPModels.ADBackend%2C%20Real%7D"
+[[jl.method]]
+name = "ADNLPModels.get_nln_nnzh-Tuple{ADNLPModels.ADModelBackend, Any}"
+uri = "reference/#ADNLPModels.get_nln_nnzh-Tuple%7BADNLPModels.ADModelBackend%2C%20Any%7D"
+[[jl.method]]
+name = "ADNLPModels.get_nln_nnzj-Tuple{ADNLPModels.ADModelBackend, Any, Any}"
+uri = "reference/#ADNLPModels.get_nln_nnzj-Tuple%7BADNLPModels.ADModelBackend%2C%20Any%2C%20Any%7D"
+[[jl.method]]
+name = "ADNLPModels.get_residual_nnzh-Tuple{ADNLPModels.ADModelBackend, Any}"
+uri = "reference/#ADNLPModels.get_residual_nnzh-Tuple%7BADNLPModels.ADModelBackend%2C%20Any%7D"
+[[jl.method]]
+name = "ADNLPModels.get_residual_nnzj-Tuple{ADNLPModels.ADModelBackend, Any, Any}"
+uri = "reference/#ADNLPModels.get_residual_nnzj-Tuple%7BADNLPModels.ADModelBackend%2C%20Any%2C%20Any%7D"
+[[jl.method]]
+name = "ADNLPModels.get_sparsity_pattern-Tuple{Union{ADNLPModels.AbstractADNLPModel{T, S}, ADNLPModels.AbstractADNLSModel{T, S}} where {T, S}, Symbol}"
+uri = "reference/#ADNLPModels.get_sparsity_pattern-Tuple%7BUnion%7BADNLPModels.AbstractADNLPModel%7BT%2C%20S%7D%2C%20ADNLPModels.AbstractADNLSModel%7BT%2C%20S%7D%7D%20where%20%7BT%2C%20S%7D%2C%20Symbol%7D"
+[[jl.method]]
+name = "ADNLPModels.set_adbackend!-Tuple{Union{ADNLPModels.AbstractADNLPModel{T, S}, ADNLPModels.AbstractADNLSModel{T, S}} where {T, S}, ADNLPModels.ADModelBackend}"
+uri = "reference/#ADNLPModels.set_adbackend%21-Tuple%7BUnion%7BADNLPModels.AbstractADNLPModel%7BT%2C%20S%7D%2C%20ADNLPModels.AbstractADNLSModel%7BT%2C%20S%7D%7D%20where%20%7BT%2C%20S%7D%2C%20ADNLPModels.ADModelBackend%7D"
+
+[[jl.type]]
+name = "ADNLPModels.ADModelBackend"
+uri = "reference/#$"
+[[jl.type]]
+name = "ADNLPModels.ADNLPModel"
+uri = "#$"
+[[jl.type]]
+name = "ADNLPModels.ADNLSModel"
+uri = "#$"
+
+[[std.doc]]
+dispname = "Backend"
+name = "backend"
+uri = "backend/"
+[[std.doc]]
+dispname = "Support multiple precision"
+name = "generic"
+uri = "generic/"
+[[std.doc]]
+dispname = "Home"
+name = "index"
+uri = ""
+[[std.doc]]
+dispname = "Build a hybrid NLPModel"
+name = "mixed"
+uri = "mixed/"
+[[std.doc]]
+dispname = "Performance tips"
+name = "performance"
+uri = "performance/"
+[[std.doc]]
+dispname = "Default backends"
+name = "predefined"
+uri = "predefined/"
+[[std.doc]]
+dispname = "Reference"
+name = "reference"
+uri = "reference/"
+[[std.doc]]
+dispname = "Sparse Jacobian and Hessian"
+name = "sparse"
+uri = "sparse/"
+[[std.doc]]
+dispname = "Providing sparsity pattern for sparse derivatives"
+name = "sparsity_pattern"
+uri = "sparsity_pattern/"
+[[std.doc]]
+dispname = "Tutorial"
+name = "tutorial"
+uri = "tutorial/"
+
+[[std.label]]
+name = "ADNLPModels"
+uri = "#$"
+[[std.label]]
+name = "Acknowledgements"
+uri = "sparse/#$"
+[[std.label]]
+dispname = "Automatic sparse differentiation (ASD)"
+name = "Automatic-sparse-differentiation-(ASD)"
+uri = "sparse/#Automatic-sparse-differentiation-%28ASD%29"
+[[std.label]]
+name = "Benchmarks"
+uri = "performance/#$"
+[[std.label]]
+dispname = "Bug reports and discussions"
+name = "Bug-reports-and-discussions"
+uri = "#$"
+[[std.label]]
+dispname = "Build a hybrid NLPModel"
+name = "Build-a-hybrid-NLPModel"
+uri = "mixed/#$"
+[[std.label]]
+dispname = "Change backend"
+name = "Change-backend"
+uri = "backend/#$"
+[[std.label]]
+dispname = "Complementary packages"
+name = "Complementary-packages"
+uri = "#$"
+[[std.label]]
+dispname = "Creating an ADNLPModels backend that supports multiple precisions"
+name = "Creating-an-ADNLPModels-backend-that-supports-multiple-precisions"
+uri = "generic/#$"
+[[std.label]]
+dispname = "Default backend and performance in ADNLPModels"
+name = "Default-backend-and-performance-in-ADNLPModels"
+uri = "predefined/#$"
+[[std.label]]
+name = "Examples"
+uri = "backend/#$"
+[[std.label]]
+dispname = "Extracting sparsity patterns"
+name = "Extracting-sparsity-patterns"
+uri = "sparse/#$"
+[[std.label]]
+dispname = "How to switch backend in ADNLPModels"
+name = "How-to-switch-backend-in-ADNLPModels"
+uri = "backend/#$"
+[[std.label]]
+name = "Index"
+uri = "reference/#$"
+[[std.label]]
+name = "Install"
+uri = "#$"
+[[std.label]]
+name = "License"
+uri = "#$"
+[[std.label]]
+dispname = "Options for sparsity pattern detection and coloring"
+name = "Options-for-sparsity-pattern-detection-and-coloring"
+uri = "sparse/#$"
+[[std.label]]
+dispname = "Performance tips"
+name = "Performance-tips"
+uri = "performance/#$"
+[[std.label]]
+dispname = "Predefined backends"
+name = "Predefined-backends"
+uri = "predefined/#$"
+[[std.label]]
+name = "Reference"
+uri = "reference/#$"
+[[std.label]]
+dispname = "Support multiple precision without having to recreate the model"
+name = "Support-multiple-precision-without-having-to-recreate-the-model"
+uri = "backend/#$"
+[[std.label]]
+name = "Tutorial"
+uri = "tutorial/#$"
+[[std.label]]
+name = "Usage"
+uri = "#$"
+[[std.label]]
+dispname = "Use another backend"
+name = "Use-another-backend"
+uri = "backend/#$"
+[[std.label]]
+dispname = "Use in-place constructor"
+name = "Use-in-place-constructor"
+uri = "performance/#$"
+[[std.label]]
+dispname = "Use only the needed backends"
+name = "Use-only-the-needed-backends"
+uri = "performance/#$"
+[[std.label]]
+dispname = "Using known sparsity patterns"
+name = "Using-known-sparsity-patterns"
+uri = "sparse/#$"
+[[std.label]]
+dispname = "Sparse Hessian and Jacobian computations"
+name = "sparse"
+uri = "sparse/#$"
+[[std.label]]
+dispname = "Improve sparse derivatives"
+name = "sparsity-pattern"
+uri = "sparsity_pattern/#$"

--- a/docs/inventories/NLPModelsIpopt.toml
+++ b/docs/inventories/NLPModelsIpopt.toml
@@ -1,0 +1,118 @@
+# DocInventory version 1
+project = "NLPModelsIpopt"
+version = "0.11.3"
+
+[[jl.function]]
+name = "NLPModelsIpopt.ipopt"
+uri = "tutorial/#$"
+
+[[jl.method]]
+name = "NLPModelsIpopt.ipopt-Tuple{NLPModels.AbstractNLPModel}"
+uri = "reference/#NLPModelsIpopt.ipopt-Tuple%7BNLPModels.AbstractNLPModel%7D"
+[[jl.method]]
+name = "NLPModelsIpopt.ipopt-Tuple{NLPModelsModifiers.FeasibilityFormNLS}"
+uri = "reference/#NLPModelsIpopt.ipopt-Tuple%7BNLPModelsModifiers.FeasibilityFormNLS%7D"
+[[jl.method]]
+name = "NLPModelsIpopt.set_callbacks-Tuple{NLPModels.AbstractNLPModel}"
+uri = "reference/#NLPModelsIpopt.set_callbacks-Tuple%7BNLPModels.AbstractNLPModel%7D"
+[[jl.method]]
+name = "SolverCore.reset!-Tuple{IpoptSolver, NLPModels.AbstractNLPModel}"
+uri = "reference/#SolverCore.reset%21-Tuple%7BIpoptSolver%2C%20NLPModels.AbstractNLPModel%7D"
+
+[[jl.type]]
+name = "NLPModelsIpopt.IpoptSolver"
+uri = "reference/#$"
+
+[[std.doc]]
+dispname = "Home"
+name = "index"
+uri = ""
+[[std.doc]]
+dispname = "Reference"
+name = "reference"
+uri = "reference/"
+[[std.doc]]
+dispname = "Performance tips"
+name = "tips"
+uri = "tips/"
+[[std.doc]]
+dispname = "Tutorial"
+name = "tutorial"
+uri = "tutorial/"
+
+[[std.label]]
+name = "AppleAccelerate"
+uri = "tips/#$"
+[[std.label]]
+dispname = "BLAS and LAPACK"
+name = "BLAS-and-LAPACK"
+uri = "tips/#$"
+[[std.label]]
+dispname = "Bug reports and discussions"
+name = "Bug-reports-and-discussions"
+uri = "#$"
+[[std.label]]
+dispname = "Callback parameters"
+name = "Callback-parameters"
+uri = "tutorial/#$"
+[[std.label]]
+dispname = "Custom stopping criteria"
+name = "Custom-stopping-criteria"
+uri = "tutorial/#$"
+[[std.label]]
+dispname = "Display backends"
+name = "Display-backends"
+uri = "tips/#$"
+[[std.label]]
+dispname = "Example usage"
+name = "Example-usage"
+uri = "tutorial/#$"
+[[std.label]]
+dispname = "Example: Using L-BFGS (limited-memory) Hessian approximation with Ipopt"
+name = "Example:-Using-L-BFGS-(limited-memory)-Hessian-approximation-with-Ipopt"
+uri = "tutorial/#Example%3A-Using-L-BFGS-%28limited-memory%29-Hessian-approximation-with-Ipopt"
+[[std.label]]
+name = "HSL"
+uri = "tips/#$"
+[[std.label]]
+name = "Index"
+uri = "reference/#$"
+[[std.label]]
+name = "Install"
+uri = "#$"
+[[std.label]]
+dispname = "Linear solvers"
+name = "Linear-solvers"
+uri = "tips/#$"
+[[std.label]]
+name = "MKL"
+uri = "tips/#$"
+[[std.label]]
+dispname = "Manual input"
+name = "Manual-input"
+uri = "tutorial/#$"
+[[std.label]]
+dispname = "Monitoring optimization with callbacks"
+name = "Monitoring-optimization-with-callbacks"
+uri = "tutorial/#$"
+[[std.label]]
+dispname = "NLPModelsIpopt.jl documentation"
+name = "NLPModelsIpopt.jl-documentation"
+uri = "#$"
+[[std.label]]
+name = "Reference"
+uri = "reference/#$"
+[[std.label]]
+dispname = "Return value"
+name = "Return-value"
+uri = "tutorial/#$"
+[[std.label]]
+name = "SPRAL"
+uri = "tips/#$"
+[[std.label]]
+dispname = "Simple problems"
+name = "Simple-problems"
+uri = "tutorial/#$"
+[[std.label]]
+name = "Tutorial"
+uri = "tutorial/#$"

--- a/docs/inventories/Tutorials.toml
+++ b/docs/inventories/Tutorials.toml
@@ -1,0 +1,449 @@
+# DocInventory version 1
+project = "Tutorials"
+version = "0.5.3"
+
+[[std.doc]]
+dispname = "Getting Started"
+name = "index"
+uri = "index.html"
+[[std.doc]]
+dispname = "Constraints at intermediate times"
+name = "tutorial-cit"
+uri = "tutorial-cit.html"
+[[std.doc]]
+dispname = "Discrete continuation"
+name = "tutorial-continuation"
+uri = "tutorial-continuation.html"
+[[std.doc]]
+dispname = "Discretisation methods"
+name = "tutorial-discretisation"
+uri = "tutorial-discretisation.html"
+[[std.doc]]
+dispname = "Final time"
+name = "tutorial-free-times-final"
+uri = "tutorial-free-times-final.html"
+[[std.doc]]
+dispname = "Final and initial times"
+name = "tutorial-free-times-final-initial"
+uri = "tutorial-free-times-final-initial.html"
+[[std.doc]]
+dispname = "Initial time"
+name = "tutorial-free-times-initial"
+uri = "tutorial-free-times-initial.html"
+[[std.doc]]
+dispname = "Goddard: direct, indirect"
+name = "tutorial-goddard"
+uri = "tutorial-goddard.html"
+[[std.doc]]
+dispname = "Indirect simple shooting"
+name = "tutorial-iss"
+uri = "tutorial-iss.html"
+[[std.doc]]
+dispname = "Linear–quadratic regulator"
+name = "tutorial-lqr"
+uri = "tutorial-lqr.html"
+[[std.doc]]
+dispname = "Minimal action"
+name = "tutorial-mam"
+uri = "tutorial-mam.html"
+[[std.doc]]
+dispname = "Model Predictive Control"
+name = "tutorial-mpc"
+uri = "tutorial-mpc.html"
+[[std.doc]]
+dispname = "NLP manipulations"
+name = "tutorial-nlp"
+uri = "tutorial-nlp.html"
+[[std.doc]]
+dispname = "Symbolic Lagrangian Mechanics"
+name = "tutorial-symbolics"
+uri = "tutorial-symbolics.html"
+
+[[std.label]]
+name = "Applications"
+uri = "index.html#$"
+[[std.label]]
+dispname = "Approach A: Using OptimalControl solver wrapper"
+name = "Approach-A:-Using-OptimalControl-solver-wrapper"
+uri = "tutorial-nlp.html#Approach-A%3A-Using-OptimalControl-solver-wrapper"
+[[std.label]]
+dispname = "Approach B: Using external NLP solvers directly"
+name = "Approach-B:-Using-external-NLP-solvers-directly"
+uri = "tutorial-nlp.html#Approach-B%3A-Using-external-NLP-solvers-directly"
+[[std.label]]
+dispname = "Augmented problem"
+name = "Augmented-problem"
+uri = "tutorial-cit.html#$"
+[[std.label]]
+dispname = "Automated Kinematics and Lagrangian"
+name = "Automated-Kinematics-and-Lagrangian"
+uri = "tutorial-symbolics.html#$"
+[[std.label]]
+dispname = "Available tutorials"
+name = "Available-tutorials"
+uri = "index.html#$"
+[[std.label]]
+dispname = "Best practices and limitations"
+name = "Best-practices-and-limitations"
+uri = "tutorial-continuation.html#$"
+[[std.label]]
+dispname = "Boundary value problem"
+name = "Boundary-value-problem"
+uri = "tutorial-iss.html#$"
+[[std.label]]
+dispname = "Canonical solve"
+name = "Canonical-solve"
+uri = "tutorial-nlp.html#$"
+[[std.label]]
+dispname = "Code Generation"
+name = "Code-Generation"
+uri = "tutorial-symbolics.html#$"
+[[std.label]]
+dispname = "Combined approaches"
+name = "Combined-approaches"
+uri = "index.html#$"
+[[std.label]]
+dispname = "Comparison of the two solvers"
+name = "Comparison-of-the-two-solvers"
+uri = "tutorial-goddard.html#$"
+[[std.label]]
+name = "Conclusion"
+uri = "tutorial-cit.html#$"
+[[std.label]]
+dispname = "Continuation on parameter"
+name = "Continuation-on-parameter"
+uri = "tutorial-continuation.html#$"
+[[std.label]]
+dispname = "Continuation on parametric OCP"
+name = "Continuation-on-parametric-OCP"
+uri = "tutorial-continuation.html#$"
+[[std.label]]
+name = "Data"
+uri = "tutorial-mpc.html#$"
+[[std.label]]
+dispname = "Definition of the problem"
+name = "Definition-of-the-problem"
+uri = "tutorial-free-times-final.html#$"
+[[std.label]]
+dispname = "Direct methods"
+name = "Direct-methods"
+uri = "index.html#$"
+[[std.label]]
+dispname = "Direct resolution"
+name = "Direct-resolution"
+uri = "tutorial-free-times-final.html#$"
+[[std.label]]
+dispname = "Direct solution"
+name = "Direct-solution"
+uri = "tutorial-free-times-initial.html#$"
+[[std.label]]
+dispname = "Direct solution: control"
+name = "Direct-solution:-control"
+uri = "tutorial-cit.html#Direct-solution%3A-control"
+[[std.label]]
+dispname = "Direct solution: state and costate"
+name = "Direct-solution:-state-and-costate"
+uri = "tutorial-cit.html#Direct-solution%3A-state-and-costate"
+[[std.label]]
+dispname = "Direct solution: trajectory"
+name = "Direct-solution:-trajectory"
+uri = "tutorial-cit.html#Direct-solution%3A-trajectory"
+[[std.label]]
+dispname = "Discretisation schemes"
+name = "Discretisation-schemes"
+uri = "tutorial-discretisation.html#$"
+[[std.label]]
+name = "Display"
+uri = "tutorial-mpc.html#$"
+[[std.label]]
+dispname = "Euler–Lagrange Equation"
+name = "Euler–Lagrange-Equation"
+uri = "tutorial-symbolics.html#Euler%E2%80%93Lagrange-Equation"
+[[std.label]]
+dispname = "Euler–Lagrange Equations and Mass-Matrix Inversion"
+name = "Euler–Lagrange-Equations-and-Mass-Matrix-Inversion"
+uri = "tutorial-symbolics.html#Euler%E2%80%93Lagrange-Equations-and-Mass-Matrix-Inversion"
+[[std.label]]
+dispname = "Example 1: a tram with intermediate stops"
+name = "Example-1:-a-tram-with-intermediate-stops"
+uri = "tutorial-cit.html#Example-1%3A-a-tram-with-intermediate-stops"
+[[std.label]]
+dispname = "Example 2: hovercraft path planning"
+name = "Example-2:-hovercraft-path-planning"
+uri = "tutorial-cit.html#Example-2%3A-hovercraft-path-planning"
+[[std.label]]
+dispname = "Explicit time grid"
+name = "Explicit-time-grid"
+uri = "tutorial-discretisation.html#$"
+[[std.label]]
+dispname = "First resolution"
+name = "First-resolution"
+uri = "tutorial-mpc.html#$"
+[[std.label]]
+name = "Fundamentals"
+uri = "index.html#$"
+[[std.label]]
+dispname = "Getting Started"
+name = "Getting-Started"
+uri = "index.html#$"
+[[std.label]]
+dispname = "Hamiltonian verification"
+name = "Hamiltonian-verification"
+uri = "tutorial-goddard.html#$"
+[[std.label]]
+dispname = "Indirect (shooting) solution"
+name = "Indirect-(shooting)-solution"
+uri = "tutorial-free-times-initial.html#Indirect-%28shooting%29-solution"
+[[std.label]]
+dispname = "Indirect methods"
+name = "Indirect-methods"
+uri = "index.html#$"
+[[std.label]]
+dispname = "Indirect shooting"
+name = "Indirect-shooting"
+uri = "tutorial-goddard.html#$"
+[[std.label]]
+dispname = "Indirect solution: control"
+name = "Indirect-solution:-control"
+uri = "tutorial-cit.html#Indirect-solution%3A-control"
+[[std.label]]
+dispname = "Indirect solution: state and costate"
+name = "Indirect-solution:-state-and-costate"
+uri = "tutorial-cit.html#Indirect-solution%3A-state-and-costate"
+[[std.label]]
+dispname = "Indirect solution: trajectory"
+name = "Indirect-solution:-trajectory"
+uri = "tutorial-cit.html#Indirect-solution%3A-trajectory"
+[[std.label]]
+dispname = "Initial Guess"
+name = "Initial-Guess"
+uri = "tutorial-mam.html#$"
+[[std.label]]
+dispname = "Initial guess"
+name = "Initial-guess"
+uri = "tutorial-goddard.html#$"
+[[std.label]]
+dispname = "Initial guess and warm start"
+name = "Initial-guess-and-warm-start"
+uri = "tutorial-nlp.html#$"
+[[std.label]]
+name = "Introduction"
+uri = "tutorial-goddard.html#$"
+[[std.label]]
+name = "Lagrangian"
+uri = "tutorial-symbolics.html#$"
+[[std.label]]
+dispname = "Large problems and AD backend"
+name = "Large-problems-and-AD-backend"
+uri = "tutorial-discretisation.html#$"
+[[std.label]]
+dispname = "MPC Approach"
+name = "MPC-Approach"
+uri = "tutorial-mpc.html#$"
+[[std.label]]
+dispname = "Minimize with respect to T"
+name = "Minimize-with-respect-to-T"
+uri = "tutorial-mam.html#$"
+[[std.label]]
+name = "Motivation"
+uri = "tutorial-cit.html#$"
+[[std.label]]
+dispname = "Optimal Control Formulation"
+name = "Optimal-Control-Formulation"
+uri = "tutorial-mam.html#$"
+[[std.label]]
+dispname = "Optimal Control Problem Definition"
+name = "Optimal-Control-Problem-Definition"
+uri = "tutorial-symbolics.html#$"
+[[std.label]]
+dispname = "Optimal Control of a Cart-Pole System using Symbolics.jl"
+name = "Optimal-Control-of-a-Cart-Pole-System-using-Symbolics.jl"
+uri = "tutorial-symbolics.html#$"
+[[std.label]]
+dispname = "OptimalControl solver"
+name = "OptimalControl-solver"
+uri = "tutorial-mpc.html#$"
+[[std.label]]
+dispname = "Physical Parameters and Symbolic Variables"
+name = "Physical-Parameters-and-Symbolic-Variables"
+uri = "tutorial-symbolics.html#$"
+[[std.label]]
+dispname = "Plot of the solution"
+name = "Plot-of-the-solution"
+uri = "tutorial-iss.html#$"
+[[std.label]]
+dispname = "Plotting the Solutions"
+name = "Plotting-the-Solutions"
+uri = "tutorial-lqr.html#$"
+[[std.label]]
+dispname = "Plotting the hovercraft solution"
+name = "Plotting-the-hovercraft-solution"
+uri = "tutorial-cit.html#$"
+[[std.label]]
+dispname = "Plotting the multi-arc solution"
+name = "Plotting-the-multi-arc-solution"
+uri = "tutorial-cit.html#$"
+[[std.label]]
+name = "Positions"
+uri = "tutorial-symbolics.html#$"
+[[std.label]]
+dispname = "Problem Setup"
+name = "Problem-Setup"
+uri = "tutorial-mam.html#$"
+[[std.label]]
+dispname = "Problem Statement"
+name = "Problem-Statement"
+uri = "tutorial-mam.html#$"
+[[std.label]]
+dispname = "Problem statement"
+name = "Problem-statement"
+uri = "tutorial-lqr.html#$"
+[[std.label]]
+name = "References"
+uri = "tutorial-goddard.html#$"
+[[std.label]]
+name = "Reproducibility"
+uri = "index.html#$"
+[[std.label]]
+dispname = "Required Packages"
+name = "Required-Packages"
+uri = "tutorial-mam.html#$"
+[[std.label]]
+dispname = "Required packages"
+name = "Required-packages"
+uri = "tutorial-lqr.html#$"
+[[std.label]]
+dispname = "Resolution of the shooting equation"
+name = "Resolution-of-the-shooting-equation"
+uri = "tutorial-iss.html#$"
+[[std.label]]
+name = "Results"
+uri = "tutorial-symbolics.html#$"
+[[std.label]]
+dispname = "Setup & Imports"
+name = "Setup-and-Imports"
+uri = "tutorial-symbolics.html#$"
+[[std.label]]
+dispname = "Simulation of the Real System"
+name = "Simulation-of-the-Real-System"
+uri = "tutorial-mpc.html#$"
+[[std.label]]
+dispname = "Solution and comparison"
+name = "Solution-and-comparison"
+uri = "tutorial-cit.html#$"
+[[std.label]]
+dispname = "Solving the NLP"
+name = "Solving-the-NLP"
+uri = "tutorial-symbolics.html#$"
+[[std.label]]
+dispname = "Solving the Problem"
+name = "Solving-the-Problem"
+uri = "tutorial-mam.html#$"
+[[std.label]]
+dispname = "Solving the problem for different final times"
+name = "Solving-the-problem-for-different-final-times"
+uri = "tutorial-lqr.html#$"
+[[std.label]]
+dispname = "State-Space Form"
+name = "State-Space-Form"
+uri = "tutorial-symbolics.html#$"
+[[std.label]]
+dispname = "Step 1: Build the initial guess"
+name = "Step-1:-Build-the-initial-guess"
+uri = "tutorial-nlp.html#Step-1%3A-Build-the-initial-guess"
+[[std.label]]
+dispname = "Step 2: Discretize the OCP"
+name = "Step-2:-Discretize-the-OCP"
+uri = "tutorial-nlp.html#Step-2%3A-Discretize-the-OCP"
+[[std.label]]
+dispname = "Step 3: Build the NLP model"
+name = "Step-3:-Build-the-NLP-model"
+uri = "tutorial-nlp.html#Step-3%3A-Build-the-NLP-model"
+[[std.label]]
+dispname = "Step 4: Solve the NLP"
+name = "Step-4:-Solve-the-NLP"
+uri = "tutorial-nlp.html#Step-4%3A-Solve-the-NLP"
+[[std.label]]
+dispname = "Step 5: Build the OCP solution"
+name = "Step-5:-Build-the-OCP-solution"
+uri = "tutorial-nlp.html#Step-5%3A-Build-the-OCP-solution"
+[[std.label]]
+dispname = "Step-by-step resolution with OptimalControl"
+name = "Step-by-step-resolution-with-OptimalControl"
+uri = "tutorial-nlp.html#$"
+[[std.label]]
+dispname = "The Cart-Pole System"
+name = "The-Cart-Pole-System"
+uri = "tutorial-symbolics.html#$"
+[[std.label]]
+dispname = "The multi-arc augmentation technique"
+name = "The-multi-arc-augmentation-technique"
+uri = "tutorial-cit.html#$"
+[[std.label]]
+dispname = "Time normalisation"
+name = "Time-normalisation"
+uri = "tutorial-cit.html#$"
+[[std.label]]
+dispname = "Visualizing Results"
+name = "Visualizing-Results"
+uri = "tutorial-mam.html#$"
+[[std.label]]
+dispname = "Discrete continuation"
+name = "tutorial-continuation"
+uri = "tutorial-continuation.html#$"
+[[std.label]]
+dispname = "Discretisation methods"
+name = "tutorial-discretisation-methods"
+uri = "tutorial-discretisation.html#$"
+[[std.label]]
+dispname = "Constraints at intermediate times"
+name = "tutorial-for-constraints-at-intermediate-times"
+uri = "tutorial-cit.html#$"
+[[std.label]]
+dispname = "Optimal control problem with free final time"
+name = "tutorial-free-times-final"
+uri = "tutorial-free-times-final.html#$"
+[[std.label]]
+dispname = "Free initial and final times"
+name = "tutorial-free-times-final-initial"
+uri = "tutorial-free-times-final-initial.html#$"
+[[std.label]]
+dispname = "Optimal control problem with free initial time"
+name = "tutorial-free-times-initial"
+uri = "tutorial-free-times-initial.html#$"
+[[std.label]]
+dispname = "Direct and indirect methods for the Goddard problem"
+name = "tutorial-goddard"
+uri = "tutorial-goddard.html#$"
+[[std.label]]
+dispname = "Plot of the solution"
+name = "tutorial-goddard-plot"
+uri = "tutorial-goddard.html#$"
+[[std.label]]
+dispname = "Structure of the solution"
+name = "tutorial-goddard-structure"
+uri = "tutorial-goddard.html#$"
+[[std.label]]
+dispname = "Indirect simple shooting"
+name = "tutorial-indirect-simple-shooting"
+uri = "tutorial-iss.html#$"
+[[std.label]]
+dispname = "A simple Linear–quadratic regulator example"
+name = "tutorial-lqr"
+uri = "tutorial-lqr.html#$"
+[[std.label]]
+dispname = "Minimal Action Method using Optimal Control"
+name = "tutorial-mam"
+uri = "tutorial-mam.html#$"
+[[std.label]]
+dispname = "Navigation problem, MPC approach"
+name = "tutorial-mpc"
+uri = "tutorial-mpc.html#$"
+[[std.label]]
+dispname = "NLP and DOCP manipulations"
+name = "tutorial-nlp"
+uri = "tutorial-nlp.html#$"
+[[std.label]]
+dispname = "Cart-Pole Periodic Orbit via Symbolic Lagrangian Mechanics"
+name = "tutorial-symbolics"
+uri = "tutorial-symbolics.html#$"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -236,7 +236,22 @@ with_api_reference(src_dir, ext_dir) do api_pages
     return makedocs(;
         draft=draft,
         remotes=nothing, # Disable remote links. Needed for DocumenterReference
-        warnonly=true,
+        # Not fully zero: 2 unresolved @ref (DOCPCache, category :cross_references) and 6
+        # unresolved @extref (CTModels.Solution / CTBase.Strategies.parameter — a *separate*
+        # category, :external_cross_references, registered by DocumenterInterLinks, not
+        # Documenter itself) are upstream defects, tracked at control-toolbox/CTDirect.jl#630,
+        # control-toolbox/CTModels.jl#416 and control-toolbox/CTBase.jl#543 respectively. Drop
+        # this exclusion once those land — see .reports/campaign/D-api-reference.md.
+        #
+        # :example_block is deliberately *not* here: the one remaining un-expanded @example
+        # (CTParser's @def docstring, control-toolbox/CTParser.jl#341, transcluded onto
+        # api/modelling.md) is a side effect of `draft` mode skipping execution and is never
+        # added to `doc.internal.errors` — confirmed by testing that a genuinely broken
+        # @example block on a Draft=false page (this file rewritten to error) still fails the
+        # build with :example_block even with this exact warnonly list, while the CTParser one
+        # stays silent either way. Excluding :example_block would have hidden real breakage for
+        # no benefit.
+        warnonly=[:cross_references, :external_cross_references],
         sitename="OptimalControl.jl",
         format=DocumenterVitepress.MarkdownVitepress(;
             repo=repo_url, devbranch="main", devurl="dev", sidebar_drawer=true


### PR DESCRIPTION
## What

`docs/make.jl` built with `warnonly=true`, so a broken docs build still exited 0 — a green CI
check proved only that the build didn't crash. This tightens it, having first traced every one of
the 14 warnings in the previous backlog to an actual cause.

**4 of 6 unresolved `@ref` — a local fix.** `docs/api_reference.jl` wrote bare symbol names into
`@docs` blocks; a bare name pulls in *every* loaded package's docstring for that binding. `:methods`
collided with `Base.methods` (its own "See also" line is `which`/`@which`/`methodswith`); `:solve`
collided with `CommonSolve.solve`, which the wider SciML ecosystem extends (one foreign docstring
mentions `NonlinearSolveBase.PostconditionSpecifier`). Both are now qualified by exact signature,
following the disambiguation pattern already used in `docs/src/results/plot.md`.

**3 of 5 inventory-load warnings — a real gap, not a sibling fallback.** `ADNLPModels.toml`,
`NLPModelsIpopt.toml`, `Tutorials.toml` didn't exist locally, but unlike the two existing empty
placeholders (`ExaModels.toml`/`MadNLP.toml`, both genuinely 404ing upstream), all three URLs are
reachable today. Harvested via `DocInventories.jl` — 57 / 31 / 114 real entries.

**The other 2 `@ref`, all 6 `@extref`, and the un-expanded `@example` — genuine upstream defects**,
filed for the maintainer to fix directly and cut new betas:
- control-toolbox/CTDirect.jl#630
- control-toolbox/CTModels.jl#416
- control-toolbox/CTBase.jl#543
- control-toolbox/CTParser.jl#341

`warnonly` becomes `[:cross_references, :external_cross_references]` — the two categories still
needed for those. `:example_block` is deliberately *not* excluded: testing the negative case
(temporarily breaking a real `@example` block) showed the CTParser warning never reaches
Documenter's error set at all (it's a `draft`-mode side effect), so excluding the category would
only have hidden real breakage for no benefit.

Full detail and root-cause tracing: `.reports/campaign/D-api-reference.md`.

## Verification

- Docs build: exit 0 before and after; verified it *fails* (exit 1) with a deliberately broken
  `@example` block, then reverted.
- Full test suite: unchanged, 2246 pass / 0 fail / 2 broken.
- No public API changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)