### PR TITLE
docs: force SVG output for Plots-generated figures

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -41,6 +41,15 @@ using JLD2
 # plotting
 using Plots
 
+# DocumenterVitepress picks the highest-priority MIME type a plot object responds to
+# (image/png: 4.0 over image/svg+xml: 3.0) — the opposite of Documenter.HTML, which
+# prefers SVG. Plots.jl (unlike CairoMakie) responds to both, so PNG wins unless this
+# is disabled. Global, not per-page: Base.showable is a method on the Plots.Plot type,
+# so setting it once here — before any @example block runs — covers every page that
+# ever calls `using Plots`, not just the ones that do today. See Handbook/VITEPRESS-DOC.md
+# "Plot image format — SVG vs PNG".
+Base.showable(::MIME"image/png", ::Plots.Plot) = false
+
 #
 function _ext(pkg, sym)
     m = Base.get_extension(pkg, sym)


### PR DESCRIPTION
## What

DocumenterVitepress picks the highest-priority MIME type a plot object responds to
(`image/png`: 4.0 over `image/svg+xml`: 3.0) — the opposite of `Documenter.HTML`, which
prefers SVG. `CairoMakie` isn't affected (its figures don't respond to `image/png` at all), but
`Plots.jl` responds to both, so PNG wins by default: every one of the 14 pages that
`using Plots` was rendering raster images instead of vector ones — a regression from the
Documenter → DocumenterVitepress migration that went unnoticed since nothing failed, the pages
just looked different.

Documented precisely in `Handbook/VITEPRESS-DOC.md` ("Plot image format — SVG vs PNG"), which
suggests a per-page `Base.showable(::MIME"image/png", ::Plots.Plot) = false` override. Applied
globally instead, once in `docs/make.jl` right where `Plots` is already loaded — `Base.showable`
is a method on the `Plots.Plot` type, so setting it before any `@example` block runs covers
every page that calls `using Plots`, present or future.

## Verification

- Rebuilt from scratch: every one of the 46 generated figures is now `.svg`. The only remaining
  `.png` in the build output is the pre-existing static `rocket-def.png` asset, untouched.
- Full test suite unchanged: 2246 pass / 0 fail / 2 broken (`docs/make.jl` isn't loaded by
  `Pkg.test()`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)