### PR TITLE
docs(modelling): trim inspect.md and without-control.md (Phase E2)

### DIFF
--- a/docs/src/modelling/inspect.md
+++ b/docs/src/modelling/inspect.md
@@ -6,6 +6,15 @@ Draft = false
 
 Once a problem is built — via [`@def`](@ref) or the [functional API](@ref modelling-functional-api) — every part of it can be read back: dimensions, names, dynamics, costs, constraints, traits. This page is about reading a model, not solving it: for that, see [Solve overview](@ref solve-overview); for the indirect/PMP route, see [Flows overview](@ref flows-overview).
 
+!!! note "Signatures and `is_*` aliases"
+    Every accessor on this page is listed with its full signature and return type in the
+    [Problem API reference](@ref api-problem). Many predicates also have an equivalent `is_*`
+    alias — `has_control` / `is_control_free`, `has_variable` / `is_variable` / `is_nonvariable`,
+    `is_autonomous` / `is_nonautonomous`, `has_fixed_final_time` / `is_final_time_fixed` (and the
+    three other time variants), `has_mayer_cost` / `is_mayer_cost_defined`,
+    `has_lagrange_cost` / `is_lagrange_cost_defined`, `has_abstract_definition` /
+    `is_abstractly_defined`. Only the `has_*` / `is_autonomous` forms are shown below.
+
 ```@example main
 using OptimalControl
 nothing # hide
@@ -26,7 +35,7 @@ end
 ocp
 ```
 
-To illustrate the accessors in the sections below, we use a richer problem: free final time, a variable, and several kinds of constraints.
+To illustrate the accessors below, we use a richer problem: free final time, a variable, and several kinds of constraints.
 
 ```@example main
 ocp = @def begin
@@ -49,560 +58,233 @@ nothing # hide
 
 ## Times
 
-The time component defines the temporal domain of the optimal control problem.
-
 ### Times model
 
-Get the times model:
-
 ```@example main
-times(ocp)  # returns the TimesModel struct containing time information
+times(ocp)  # the TimesModel struct
 ```
 
-You can also access initial and final times separately:
-
-```@example main
-initial_time(ocp)  # returns the initial time value
-```
-
-For the final time, if it is free (part of the variable), you need to provide the variable value:
-
-```@example main
-v = [1, 2]  # example variable values: w=1, tf=2
-final_time(ocp, v)  # returns tf value from variable
-```
-
-If you try to get the final time without providing the variable when it's free, an error occurs:
+Initial and final times separately. The final time needs the variable value when it is free:
 
 ```@repl main
-final_time(ocp)  # error: tf is free, need variable
+initial_time(ocp)
+final_time(ocp, [1, 2])   # w = 1, tf = 2
+```
+
+Asking for a free final time without the variable errors:
+
+```@repl main
+final_time(ocp)
 ```
 
 ### Time variable names
 
-Get the names of the time variable and time bounds:
-
-```@example main
-time_name(ocp)  # returns "s" (the time variable name in this OCP)
-```
-
-```@example main
-initial_time_name(ocp)  # returns "0" (initial time is fixed at 0)
-```
-
-```@example main
-final_time_name(ocp)  # returns "tf" (final time is a variable)
+```@repl main
+time_name(ocp)           # "s"
+initial_time_name(ocp)   # "0" — fixed
+final_time_name(ocp)     # "tf" — a variable
 ```
 
 ### Time fixedness predicates
 
-Check whether initial or final times are fixed or free:
-
-```@example main
-has_fixed_initial_time(ocp)  # true if t0 is fixed
-```
-
-```@example main
-has_free_initial_time(ocp)  # true if t0 is free (part of variable)
-```
-
-!!! note "Variant methods"
-    Alternative methods with `is_*` prefix are also available and equivalent:
-    - `is_initial_time_fixed(ocp)` ≡ `has_fixed_initial_time(ocp)`
-    - `is_initial_time_free(ocp)` ≡ `has_free_initial_time(ocp)`
-    - `is_final_time_fixed(ocp)` ≡ `has_fixed_final_time(ocp)`
-    - `is_final_time_free(ocp)` ≡ `has_free_final_time(ocp)`
-
-Similarly for final time:
-
-```@example main
-has_fixed_final_time(ocp)  # false (tf is free in this OCP)
-```
-
-```@example main
-has_free_final_time(ocp)  # true (tf is part of variable v)
+```@repl main
+has_fixed_initial_time(ocp)
+has_free_initial_time(ocp)
+has_fixed_final_time(ocp)
+has_free_final_time(ocp)
 ```
 
 ### Autonomy
 
-Check if the dynamics and Lagrange cost are autonomous (time-independent):
-
 ```@example main
-is_autonomous(ocp)  # false if dynamics or cost depend on time
+is_autonomous(ocp)  # false if the dynamics or the Lagrange cost depend on time
 ```
 
-For more details on autonomy, see the [Time dependence](@ref modelling-inspect-time-dependence) section below.
-
-### [Summary table](@id modelling-inspect-summary-time)
-
-| Method | Returns | Description |
-| -------- | --------- | --------- |
-| `times(ocp)` | `(Float64, Any)` | Time interval (t0, tf) or (t0, tf_name) |
-| `initial_time(ocp)` | `Float64` | Initial time t0 |
-| `final_time(ocp)` | `Float64` | Final time tf (error if free) |
-| `final_time(ocp, v)` | `Float64` | Final time tf from variable v |
-| `time_name(ocp)` | `String` | Time variable name |
-| `initial_time_name(ocp)` | `String` | Initial time name or value |
-| `final_time_name(ocp)` | `String` | Final time name or value |
-| `has_fixed_initial_time(ocp)` | `Bool` | True if t0 is fixed |
-| `has_free_initial_time(ocp)` | `Bool` | True if t0 is free |
-| `has_fixed_final_time(ocp)` | `Bool` | True if tf is fixed |
-| `has_free_final_time(ocp)` | `Bool` | True if tf is free |
-| `is_autonomous(ocp)` | `Bool` | True if time-independent |
+See [Time dependence](@ref modelling-inspect-time-dependence) below.
 
 ## State
 
-The state component represents the state variables of the optimal control problem.
-
 ### State component information
 
-Get the name, dimension, and component names of the state:
-
-```@example main
-state_name(ocp)  # returns "q" (the state variable name)
-```
-
-```@example main
-state_dimension(ocp)  # returns 2 (dimension of state)
-```
-
-```@example main
-state_components(ocp)  # returns ["x", "y"] (component names)
+```@repl main
+state_name(ocp)
+state_dimension(ocp)
+state_components(ocp)
 ```
 
 !!! note
-
     The component names are used when plotting the solution. See [Plot](@ref results-plot).
 
 ### State box constraints
 
-Get the box constraints on the state (lower and upper bounds):
-
 ```@example main
-state_constraints_box(ocp)  # returns box constraints if any
+state_constraints_box(ocp)
 ```
 
-!!! note "Tuple structure"
-    The returned tuple has the structure `(lb, indices, ub, labels, aliases)` where:
-    - `lb`: vector of lower bounds
-    - `indices`: vector of component indices (1-based)
-    - `ub`: vector of upper bounds
-    - `labels`: vector of constraint labels
-    - `aliases`: vector of vectors containing all labels that declared each component
+!!! note "Tuple structures"
+    Box-constraint accessors (`state_constraints_box`, `control_constraints_box`,
+    `variable_constraints_box`) return `(lb, indices, ub, labels, aliases)`:
+    - `lb`, `ub` — vectors of lower / upper bounds
+    - `indices` — component indices (1-based)
+    - `labels` — constraint labels
+    - `aliases` — for each component, every label that declared it
 
-Get the dimension of state box constraints:
+    The nonlinear-constraint accessors (`path_constraints_nl`, `boundary_constraints_nl`)
+    return `(lb, f!, ub, labels)` instead, with `f!` in-place: `f!(val, t, x, u, v)` for path
+    constraints, `f!(val, x0, xf, v)` for boundary constraints.
 
 ```@example main
-dim_state_constraints_box(ocp)  # returns number of box constraints on state
+dim_state_constraints_box(ocp)
 ```
-
-### [Summary table](@id modelling-inspect-summary-state)
-
-| Method | Returns | Description |
-| -------- | --------- | --------- |
-| `state_name(ocp)` | `String` | State variable name |
-| `state_dimension(ocp)` | `Int` | State dimension |
-| `state_components(ocp)` | `Vector{String}` | State component names |
-| `state_constraints_box(ocp)` | Box constraints | State box constraints |
-| `dim_state_constraints_box(ocp)` | `Int` | Number of state box constraints |
 
 ## Control
 
-The control component represents the control variables of the optimal control problem.
-
 ### Control component information
 
-Get the name, dimension, and component names of the control:
-
-```@example main
-control_name(ocp)  # returns "u" (the control variable name)
-```
-
-```@example main
-control_dimension(ocp)  # returns 1 (dimension of control)
-```
-
-```@example main
-control_components(ocp)  # returns ["u"] (component names)
+```@repl main
+control_name(ocp)
+control_dimension(ocp)
+control_components(ocp)
 ```
 
 ### Control box constraints
 
-Get the box constraints on the control:
-
-```@example main
-control_constraints_box(ocp)  # returns box constraints if any
-```
-
-!!! note "Tuple structure"
-    The returned tuple has the structure `(lb, indices, ub, labels, aliases)` where:
-    - `lb`: vector of lower bounds
-    - `indices`: vector of component indices (1-based)
-    - `ub`: vector of upper bounds
-    - `labels`: vector of constraint labels
-    - `aliases`: vector of vectors containing all labels that declared each component
-
-Get the dimension of control box constraints:
-
-```@example main
-dim_control_constraints_box(ocp)  # returns number of box constraints on control
+```@repl main
+control_constraints_box(ocp)
+dim_control_constraints_box(ocp)
 ```
 
 ### Control presence
 
-Check whether the problem has a control input:
-
 ```@example main
-has_control(ocp)  # true if problem has a control input
+has_control(ocp)  # true if the problem has a control input
 ```
 
-!!! note "Variant method"
-
-    - `is_control_free(ocp)` ≡ `!has_control(ocp)`. See [Problems without a control](@ref modelling-without-control).
-
-### [Summary table](@id modelling-inspect-summary-control)
-
-| Method | Returns | Description |
-| -------- | --------- | --------- |
-| `control_name(ocp)` | `String` | Control variable name |
-| `control_dimension(ocp)` | `Int` | Control dimension |
-| `control_components(ocp)` | `Vector{String}` | Control component names |
-| `control_constraints_box(ocp)` | Box constraints | Control box constraints |
-| `dim_control_constraints_box(ocp)` | `Int` | Number of control box constraints |
-| `has_control(ocp)` | `Bool` | True if problem has a control input |
-| `is_control_free(ocp)` | `Bool` | True if problem has no control (`≡ !has_control`) |
+`is_control_free(ocp) ≡ !has_control(ocp)` — see [Problems without a control](@ref modelling-without-control).
 
 ## Variable
 
-The variable component represents the optimization variables (parameters) of the optimal control problem.
-
 ### Variable component information
 
-Get the name, dimension, and component names of the variable:
-
-```@example main
-variable_name(ocp)  # returns "v" (the variable name)
-```
-
-```@example main
-variable_dimension(ocp)  # returns 2 (dimension of variable)
-```
-
-```@example main
-variable_components(ocp)  # returns ["w", "tf"] (component names)
+```@repl main
+variable_name(ocp)
+variable_dimension(ocp)
+variable_components(ocp)
 ```
 
 ### Variable box constraints
 
-Get the box constraints on the variable:
-
-```@example main
-variable_constraints_box(ocp)  # returns box constraints if any
-```
-
-!!! note "Tuple structure"
-    The returned tuple has the structure `(lb, indices, ub, labels, aliases)` where:
-    - `lb`: vector of lower bounds
-    - `indices`: vector of component indices (1-based)
-    - `ub`: vector of upper bounds
-    - `labels`: vector of constraint labels
-    - `aliases`: vector of vectors containing all labels that declared each component
-
-Get the dimension of variable box constraints:
-
-```@example main
-dim_variable_constraints_box(ocp)  # returns number of box constraints on variable
+```@repl main
+variable_constraints_box(ocp)
+dim_variable_constraints_box(ocp)
 ```
 
 ### Variable presence
 
-Check whether the problem has optimization variables:
-
 ```@example main
-has_variable(ocp)  # true if problem has optimization variables
+has_variable(ocp)  # true if the problem has optimisation variables
 ```
-
-!!! note "Variant methods"
-
-    - `is_variable(ocp)` ≡ `has_variable(ocp)`
-    - `is_nonvariable(ocp)` ≡ `!has_variable(ocp)`
-
-### [Summary table](@id modelling-inspect-summary-variable)
-
-| Method | Returns | Description |
-| -------- | --------- | --------- |
-| `variable_name(ocp)` | `String` | Variable name |
-| `variable_dimension(ocp)` | `Int` | Variable dimension |
-| `variable_components(ocp)` | `Vector{String}` | Variable component names |
-| `variable_constraints_box(ocp)` | Box constraints | Variable box constraints |
-| `dim_variable_constraints_box(ocp)` | `Int` | Number of variable box constraints |
-| `has_variable(ocp)` | `Bool` | True if problem has optimization variables |
-| `is_variable(ocp)` | `Bool` | Alias for `has_variable` |
-| `is_nonvariable(ocp)` | `Bool` | True if problem has no variables (`≡ !has_variable`) |
 
 ## Dynamics
 
-The dynamics component defines the differential equations governing the state evolution.
-
-### Dynamics function
-
-The dynamics are stored as an in-place function of the form `f!(dx, t, x, u, v)`:
+The dynamics are stored as an in-place function `f!(dx, t, x, u, v)` — `dx` is mutated, the other arguments are time, state, control, variable:
 
 ```@example main
 f! = dynamics(ocp)
-s = 0.5  # time
-q = [0.0, 1.0]  # state
-u = 2.0  # control (scalar: control_dimension(ocp) == 1)
-v = [1.0, 2.0]  # variable
+s = 0.5; q = [0.0, 1.0]; u = 2.0; v = [1.0, 2.0]
 dq = similar(q)
 f!(dq, s, q, u, v)
-dq  # returns the derivative q̇
+dq  # the state derivative q̇
 ```
-
-The first argument `dx` is mutated upon call and contains the state derivative. The other arguments are:
-
-* `t`: time
-* `x`: state
-* `u`: control
-* `v`: variable
-
-### [Summary table](@id modelling-inspect-summary-dynamics)
-
-| Method | Returns | Description |
-| -------- | --------- | --------- |
-| `dynamics(ocp)` | `Function` | In-place dynamics function f!(dx, t, x, u, v) |
 
 ## Objective
 
-The objective component defines the cost function to minimize or maximize.
-
-### Criterion
-
-The criterion indicates whether the problem is a minimization or maximization:
-
 ```@example main
-criterion(ocp)  # returns :min or :max
+criterion(ocp)  # :min or :max
 ```
 
-### Objective form
-
-The objective function can be in Mayer form, Lagrange form, or Bolza form (combination of both):
-
-* **Mayer**: $g(x(t_0), x(t_f), v) \to \min$
-* **Lagrange**: $\int_{t_0}^{t_f} f^0(t, x(t), u(t), v)\, \mathrm{d}t \to \min$
-* **Bolza**: $g(x(t_0), x(t_f), v) + \int_{t_0}^{t_f} f^0(t, x(t), u(t), v)\, \mathrm{d}t \to \min$
-
-Check which form is present:
-
-```@example main
-has_mayer_cost(ocp)  # true if Mayer cost exists
-```
-
-```@example main
-has_lagrange_cost(ocp)  # true if Lagrange cost exists
-```
-
-!!! note "Variant methods"
-    Alternative methods are also available:
-    - `is_mayer_cost_defined(ocp)` ≡ `has_mayer_cost(ocp)`
-    - `is_lagrange_cost_defined(ocp)` ≡ `has_lagrange_cost(ocp)`
-
-### Mayer cost
-
-Get the Mayer cost function with signature `g(x0, xf, v)`:
+The objective is in Mayer form $g(x(t_0), x(t_f), v)$, Lagrange form $\int_{t_0}^{t_f} f^0(t, x(t), u(t), v)\, \mathrm{d}t$, or Bolza form (both):
 
 ```@repl main
-g = mayer(ocp)  # error if no Mayer cost
+has_mayer_cost(ocp)
+has_lagrange_cost(ocp)
 ```
 
-### Lagrange cost
+Get the cost functions — `mayer` has signature `g(x0, xf, v)` and errors when there is no Mayer cost; `lagrange` has signature `f⁰(t, x, u, v)`:
 
-Get the Lagrange cost function with signature `f⁰(t, x, u, v)`:
+```@repl main
+mayer(ocp)
+```
 
 ```@example main
 f⁰ = lagrange(ocp)
-s = 0.5
-q = [0.0, 1.0]
-u = 2.0
-v = [1.0, 2.0]
-f⁰(s, q, u, v)  # returns the integrand value
+f⁰(0.5, [0.0, 1.0], 2.0, [1.0, 2.0])  # the integrand value
 ```
-
-### [Summary table](@id modelling-inspect-summary-objective)
-
-| Method | Returns | Description |
-| -------- | --------- | --------- |
-| `criterion(ocp)` | `Symbol` | `:min` or `:max` |
-| `has_mayer_cost(ocp)` | `Bool` | True if Mayer cost exists |
-| `has_lagrange_cost(ocp)` | `Bool` | True if Lagrange cost exists |
-| `mayer(ocp)` | `Function` | Mayer cost function g(x0, xf, v) |
-| `lagrange(ocp)` | `Function` | Lagrange cost function f⁰(t, x, u, v) |
 
 ## Constraints
 
-The constraints component defines the constraints on the optimal control problem.
-
 ### Individual constraints
 
-Retrieve a specific constraint by its label using the `constraint` function. It returns a tuple `(type, f, lb, ub)`:
+`constraint(ocp, label)` returns `(type, f, lb, ub)`. The function signature is `f(x0, xf, v)` for `:boundary` and `:variable` constraints, `f(t, x, u, v)` for `:control`, `:state` and `:mixed` ones:
 
 ```@example main
+x0 = [0, 1]; xf = [2, 3]; v = [1, 4]
+s = 0.5; q = [1.0, 2.0]; u = 3.0
+
 (type, f, lb, ub) = constraint(ocp, :eq1)
-println("type: ", type)
-x0 = [0, 1]
-xf = [2, 3]
-v  = [1, 4]
-println("val: ", f(x0, xf, v))
-println("lb: ", lb)
-println("ub: ", ub)
-```
-
-The function signature depends on the constraint type:
-
-* For `:boundary` and `:variable` constraints: `f(x0, xf, v)`
-* For other constraints (`:control`, `:state`, `:mixed`): `f(t, x, u, v)`
-
-Examples of different constraint types:
-
-```@example main
-(type, f, lb, ub) = constraint(ocp, :cons_bound)
-println("type: ", type)
-println("val: ", f(x0, xf, v))
+(type, f(x0, xf, v), lb, ub)
 ```
 
 ```@example main
-(type, f, lb, ub) = constraint(ocp, :cons_u)
-println("type: ", type)
-s = 0.5
-q = [1.0, 2.0]
-u = 3.0
-println("val: ", f(s, q, u, v))
+(type, f, lb, ub) = constraint(ocp, :cons_bound)   # a boundary constraint
+(type, f(x0, xf, v))
 ```
 
 ```@example main
-(type, f, lb, ub) = constraint(ocp, :cons_mixed)
-println("type: ", type)
-println("val: ", f(s, q, u, v))
-```
-
-### All constraints
-
-Get all constraints as a collection:
-
-```@example main
-constraints(ocp)  # returns all constraints
-```
-
-### Nonlinear constraints
-
-Get nonlinear path and boundary constraints:
-
-```@example main
-path_constraints_nl(ocp)  # returns nonlinear path constraints
+(type, f, lb, ub) = constraint(ocp, :cons_u)       # a control constraint
+(type, f(s, q, u, v))
 ```
 
 ```@example main
-boundary_constraints_nl(ocp)  # returns nonlinear boundary constraints
+(type, f, lb, ub) = constraint(ocp, :cons_mixed)   # a path (mixed state–control) constraint
+(type, f(s, q, u, v))
 ```
 
-!!! note "Tuple structure"
-    The returned tuples have the structure `(lb, f!, ub, labels)` where:
-    - `lb`: vector of lower bounds
-    - `f!`: constraint function (in-place)
-    - `ub`: vector of upper bounds
-    - `labels`: vector of constraint labels
-
-    The constraint functions have the following signatures:
-    - Path constraints: `f!(val, t, x, u, v)` where `val` is mutated
-    - Boundary constraints: `f!(val, x0, xf, v)` where `val` is mutated
-
-Get the dimensions of nonlinear constraints:
+### All constraints, and nonlinear ones
 
 ```@example main
-dim_path_constraints_nl(ocp)  # number of nonlinear path constraints
+constraints(ocp)
 ```
 
-```@example main
-dim_boundary_constraints_nl(ocp)  # number of nonlinear boundary constraints
+```@repl main
+path_constraints_nl(ocp)
+boundary_constraints_nl(ocp)
+dim_path_constraints_nl(ocp)
+dim_boundary_constraints_nl(ocp)
 ```
 
 !!! note
-
-    To get the dual variable (or Lagrange multiplier) associated to a constraint, use the [`dual`](@ref) method on a solution — see [Solution object](@ref results-solution).
-
-### [Summary table](@id modelling-inspect-summary-constraints)
-
-| Method | Returns | Description |
-| -------- | --------- | --------- |
-| `constraint(ocp, label)` | `(Symbol, Function, Real, Real)` | Get constraint by label |
-| `constraints(ocp)` | Collection | All constraints |
-| `path_constraints_nl(ocp)` | Constraints | Nonlinear path constraints |
-| `boundary_constraints_nl(ocp)` | Constraints | Nonlinear boundary constraints |
-| `dim_path_constraints_nl(ocp)` | `Int` | Number of nonlinear path constraints |
-| `dim_boundary_constraints_nl(ocp)` | `Int` | Number of nonlinear boundary constraints |
+    To get the dual variable (Lagrange multiplier) of a constraint, use [`dual`](@ref) on a
+    solution — see [Solution object](@ref results-solution).
 
 ## Problem definition
 
-Get the problem definition as a string:
-
 ```@example main
-definition(ocp)  # returns the OCP definition as AbstractDefinition
+definition(ocp)  # the OCP definition, an AbstractDefinition
 ```
 
-To extract the expression from the definition, use:
-
 ```@example main
-expr = expression(ocp)  # returns the Expr from the definition
+expr = expression(ocp)  # the Expr from the definition
 nothing # hide
 ```
 
-!!! note
-
-    The definition is optional and can be `EmptyDefinition` — this is what the [functional API](@ref modelling-functional-api) produces. Use `has_abstract_definition(ocp)` to check if a definition is present.
-
-### Definition presence
-
-Check whether the problem carries an abstract definition:
-
 ```@example main
-has_abstract_definition(ocp)  # true if definition is present (not EmptyDefinition)
+has_abstract_definition(ocp)  # false for a functional-API model (EmptyDefinition)
 ```
-
-!!! note "Variant method"
-
-    - `is_abstractly_defined(ocp)` ≡ `has_abstract_definition(ocp)`
 
 ## [Time dependence](@id modelling-inspect-time-dependence)
 
-Optimal control problems can be **autonomous** or **non-autonomous**. In an autonomous problem, neither the dynamics nor the Lagrange cost explicitly depends on the time variable.
-
-The following problem is autonomous.
-
-```@example main
-ocp = @def begin
-    t ∈ [ 0, 1 ], time
-    x ∈ R, state
-    u ∈ R, control
-    ẋ(t)  == u(t)                       # no explicit dependence on t
-    x(1) + 0.5∫( u(t)^2 ) → min         # no explicit dependence on t
-end
-is_autonomous(ocp)
-```
-
-The following problem is non-autonomous since the dynamics depends on `t`.
-
-```@example main
-ocp = @def begin
-    t ∈ [ 0, 1 ], time
-    x ∈ R, state
-    u ∈ R, control
-    ẋ(t)  == u(t) + t                   # explicit dependence on t
-    x(1) + 0.5∫( u(t)^2 ) → min
-end
-is_autonomous(ocp)
-```
-
-Finally, this last problem is non-autonomous because the Lagrange part of the cost depends on `t`.
+A problem is **autonomous** when neither the dynamics nor the Lagrange cost depends explicitly on the time variable, **non-autonomous** otherwise.
 
 ```@example main
 ocp = @def begin
@@ -610,20 +292,27 @@ ocp = @def begin
     x ∈ R, state
     u ∈ R, control
     ẋ(t)  == u(t)
-    x(1) + 0.5∫( t + u(t)^2 ) → min     # explicit dependence on t
+    x(1) + 0.5∫( u(t)^2 ) → min
 end
 is_autonomous(ocp)
 ```
 
-The variant predicate `is_nonautonomous` is also available and returns the opposite of `is_autonomous`:
+Adding an explicit `t` to the dynamics (or to the Lagrange integrand) makes it non-autonomous:
 
 ```@example main
-is_nonautonomous(ocp)  # true if dynamics or cost depend on time
+ocp = @def begin
+    t ∈ [ 0, 1 ], time
+    x ∈ R, state
+    u ∈ R, control
+    ẋ(t)  == u(t) + t                  # explicit dependence on t
+    x(1) + 0.5∫( u(t)^2 ) → min
+end
+is_autonomous(ocp)
 ```
 
-!!! note "Variant method"
-
-    - `is_nonautonomous(ocp)` ≡ `!is_autonomous(ocp)`
+```@example main
+is_nonautonomous(ocp)  # the negation of is_autonomous
+```
 
 ## API trap: `time` is gone
 

--- a/docs/src/modelling/without-control.md
+++ b/docs/src/modelling/without-control.md
@@ -11,7 +11,9 @@ Control-free problems are optimal control problems without a control variable �
 - identifying unknown parameters from observed data (parameter estimation),
 - finding optimal parameters for a given performance criterion.
 
-This page demonstrates two examples with known analytical solutions, solved both directly and indirectly.
+This page is the modelling-side guide: how to declare such a problem and the traps around it.
+For the full worked story — both examples below solved **direct and indirect** — see
+[Parameter estimation without a control](@ref examples-control-free).
 
 ## How to declare it
 
@@ -24,36 +26,30 @@ There is no dedicated syntax for "no control": simply never declare one. Declare
     called `control!` keeps its default `EmptyControlModel`, and `is_control_free`/`has_control`
     read that from the *type* of the built model's control field, not from a dimension check.
 
-```@example main-growth
+```@example main
 using OptimalControl
 using NLPModelsIpopt
 using Plots
 ```
 
-## Worked example: exponential growth
+## Example: parameter estimation
 
-Consider a system with exponential growth:
-
-```math
-\dot{x}(t) = \lambda \cdot x(t), \quad x(0) = 2
-```
-
-where $\lambda$ is an unknown growth rate parameter. We have observed data with some perturbations and want to estimate $\lambda$ by minimising the squared error:
+A system with exponential growth, $\dot{x}(t) = \lambda\, x(t)$, $x(0) = 2$, where $\lambda$
+is an unknown growth rate. We have noisy observed data and estimate $\lambda$ by minimising
+the squared error:
 
 ```math
 \min_{\lambda} \int_0^{2} (x(t) - x_{\text{obs}}(t))^2 \, \mathrm{d}t
 ```
 
-The underlying model has $\lambda = 0.5$, but the observed data includes perturbations.
+The underlying model has $\lambda = 0.5$; the data adds a perturbation. Note there is **no
+control line** — only a `variable`:
 
-```@example main-growth
-# observed data (analytical solution with λ = 0.5)
+```@example main
+# observed data (analytical solution with λ = 0.5, plus a perturbation)
 λ_true = 0.5
-model(t) = 2 * exp(λ_true * t)
-perturbation(t) = 2e-1*sin(4π*t)
-data(t) = model(t) + perturbation(t)
+data(t) = 2 * exp(λ_true * t) + 2e-1 * sin(4π * t)
 
-# optimal control problem (parameter estimation)
 t0 = 0; tf = 2; x0 = 2
 ocp = @def begin
     λ ∈ R, variable              # growth rate to estimate
@@ -68,269 +64,47 @@ end
 nothing # hide
 ```
 
-### Direct method
+It solves like any other problem:
 
-```@example main-growth
-direct_sol = solve(ocp; grid_size=20, display=false)
-```
-
-```@example main-growth
-println("Estimated growth rate: λ = ", variable(direct_sol))
-println("Objective value: ", objective(direct_sol))
+```@example main
+sol = solve(ocp; grid_size=20, display=false)
+println("estimated λ = ", variable(sol), "   (true value: ", λ_true, ")")
 nothing # hide
 ```
 
-```@example main-growth
-plt = plot(direct_sol, :state; size=(800, 400), label="Direct")
-t_grid = time_grid(direct_sol)
-plot!(plt, t_grid, data.(t_grid); subplot=1, line=:dot, lw=2, label="Data", color=:black)
+```@example main
+plt = plot(sol, :state; size=(800, 400), label="Direct")
+tg = time_grid(sol)
+plot!(plt, tg, data.(tg); subplot=1, line=:dot, lw=2, label="Data", color=:black)
 ```
 
-The estimated parameter should be close to $\lambda \approx 0.5$.
+The estimate is close to $\lambda \approx 0.5$. The indirect (PMP shooting) solution of the
+same problem is worked in full in [Parameter estimation without a control](@ref examples-control-free).
 
-### Indirect method
+## Example: harmonic oscillator
 
-We now solve the same problem using an indirect shooting method based on Pontryagin's Maximum Principle.
+The same shape with a Mayer cost — minimise the pulsation $\omega$ of $\ddot q = -\omega^2 q$
+under $q(0) = 1$, $\dot q(0) = 0$, $q(1) = 0$ (analytical solution $\omega = \pi/2$):
 
-```@example main-growth
-using OrdinaryDiffEq  # ODE solver
-using NonlinearSolve  # Nonlinear solver
-```
-
-For control-free problems with a variable parameter, we use an **augmented Hamiltonian** approach. The Hamiltonian for this problem is:
-
-```math
-H(t, x, p, \lambda) = p \lambda x - (x - x_{\text{obs}}(t))^2
-```
-
-To handle the variable parameter $\lambda$, we treat it as an additional state with zero dynamics. This gives us the augmented system with state $(x, \lambda)$ and costate $(p, p_\lambda)$, where:
-
-```math
-\begin{aligned}
-\frac{\mathrm{d}x}{\mathrm{d}t} &= \frac{\partial H}{\partial p} = \lambda x \\
-\frac{\mathrm{d}\lambda}{\mathrm{d}t} &= 0 \quad \text{(constant parameter)} \\
-\frac{\mathrm{d}p}{\mathrm{d}t} &= -\frac{\partial H}{\partial x} = -p\lambda + 2(x - x_{\text{obs}}(t)) \\
-\frac{\mathrm{d}p_\lambda}{\mathrm{d}t} &= -\frac{\partial H}{\partial \lambda} = -px
-\end{aligned}
-```
-
-The transversality condition for the variable parameter requires $p_\lambda(t_f) - p_\lambda(t_0) = 0$. Assuming $p_\lambda(t_0) = 0$, we have to satisfy:
-
-```math
-p_\lambda(t_f) = -\int_{t_0}^{t_f} \frac{\partial H}{\partial \lambda}(t, x(t), p(t), \lambda) \, \mathrm{d}t = 0
-```
-
-We use `variable_costate=true` to automatically compute $p_\lambda(t_f)$ without manually constructing the augmented system.
-
-```@example main-growth
-# Create Hamiltonian flow from the control-free OCP
-f = Flow(ocp)
-nothing # hide
-```
-
-!!! note
-
-    For more on building flows from an OCP, see [Flows overview](@ref flows-overview) and
-    [From an OCP](@ref flows-from-ocp).
-
-The shooting function enforces the transversality conditions $p(t_f) = 0$ and $p_\lambda(t_f) = 0$. With `variable_costate=true`, the flow returns $(x(t_f), p(t_f), p_\lambda(t_f))$, with $p_\lambda(t_0) = 0$ by construction. The variable is passed as a keyword, `variable=λ`:
-
-```@example main-growth
-# Shooting function: S(p0, λ) = (p(tf), pλ(tf))
-function shoot!(s, p0, λ)
-    _, px_tf, pλ_tf = f(t0, x0, p0, tf; variable=λ, variable_costate=true)
-    s[1] = px_tf
-    s[2] = pλ_tf
-    return nothing
-end
-
-# Auxiliary in-place NLE function
-nle!(s, y, _) = shoot!(s, y...)
-nothing # hide
-```
-
-We use the direct solution to initialise the shooting method:
-
-```@example main-growth
-p_direct = costate(direct_sol)
-λ_direct = variable(direct_sol)
-
-p0_guess = p_direct(t0)
-λ_guess = λ_direct
-
-prob_indirect = NonlinearProblem(nle!, [p0_guess, λ_guess])
-shooting_sol = solve(prob_indirect; show_trace=Val(false))
-p0_sol, λ_sol = shooting_sol.u
-
-println("Indirect solution:")
-println("Initial costate: p0 = ", p0_sol)
-println("Parameter: λ = ", λ_sol)
-nothing # hide
-```
-
-Finally, we compute and plot the indirect solution — the trajectory call takes no `saveat`, it returns a full solution over the flow's own grid:
-
-```@example main-growth
-indirect_sol = f((t0, tf), x0, p0_sol; variable=λ_sol)
-plot!(plt, indirect_sol, :state; linestyle=:dash, lw=2, label="Indirect", color=2)
-```
-
-The direct and indirect solutions match closely, both fitting the perturbed observed data.
-
-## Worked example: harmonic oscillator
-
-```@setup main-harmonic
-using OptimalControl
-using NLPModelsIpopt
-using Plots
-using OrdinaryDiffEq
-using NonlinearSolve
-```
-
-Consider a harmonic oscillator:
-
-```math
-\ddot{q}(t) = -\omega^2 q(t)
-```
-
-with initial conditions $q(0) = 1$, $\dot{q}(0) = 0$ and final condition $q(1) = 0$. We want to find the minimal pulsation $\omega$ satisfying these constraints:
-
-```math
-    \begin{aligned}
-        & \text{Minimise} && \omega^2 \\
-        & \text{subject to} \\
-        & && \ddot{q}(t) = -\omega^2 q(t), \\[1.0em]
-        & && q(0) = 1, \quad \dot{q}(0) = 0, \\[0.5em]
-        & && q(1) = 0.
-    \end{aligned}
-```
-
-The analytical solution is $\omega = \pi/2 \approx 1.5708$, giving $q(t) = \cos(\pi t / 2)$.
-
-```@example main-harmonic
-q0 = 1; v0 = 0
-t0 = 0; tf = 1
+```@example main
 ocp = @def begin
-    ω ∈ R, variable              # pulsation to optimize
-    t ∈ [t0, tf], time
+    ω ∈ R, variable              # pulsation to minimise
+    t ∈ [0, 1], time
     x = (q, v) ∈ R², state
 
-    q(t0) == q0
-    v(t0) == v0
-    q(tf) == 0.0                  # final condition
+    q(0) == 1.0
+    v(0) == 0.0
+    q(1) == 0.0
 
     ẋ(t) == [v(t), -ω^2 * q(t)]
 
-    ω^2 → min   # minimize pulsation
+    ω^2 → min
 end
 nothing # hide
 ```
 
-### Direct method
-
-```@example main-harmonic
-direct_sol = solve(ocp; grid_size=20, display=false)
-```
-
-```@example main-harmonic
-println("Optimal pulsation: ω = ", variable(direct_sol))
-println("Objective value: ω² = ", objective(direct_sol))
-println("Expected: ω = π/2 ≈ 1.5708, ω² ≈ 2.4674")
-nothing # hide
-```
-
-```@example main-harmonic
-plot(direct_sol, :state; size=(800, 400))
-```
-
-### Comparison with the analytical solution
-
-```@example main-harmonic
-t_analytical = range(0, 1, 100)
-q_analytical = cos.(π * t_analytical / 2)
-v_analytical = -(π/2) * sin.(π * t_analytical / 2)
-
-plt = plot(direct_sol, :state; size=(800, 600), label="Direct")
-plot!(plt, t_analytical, q_analytical;
-      label="q (analytical)", linestyle=:dash, linewidth=2, subplot=1)
-plot!(plt, t_analytical, v_analytical;
-      label="v (analytical)", linestyle=:dash, linewidth=2, subplot=2)
-```
-
-The numerical and analytical solutions should match closely.
-
-### Indirect method
-
-For this control-free problem with a variable parameter, we again use the augmented-Hamiltonian approach. The Hamiltonian is:
-
-```math
-H(x, p, \omega) = p_1 v + p_2 (-\omega^2 q)
-```
-
-Treating $\omega$ as an additional state with zero dynamics gives the augmented system with state $(q, v, \omega)$ and costate $(p_1, p_2, p_\omega)$:
-
-```math
-\begin{aligned}
-\frac{\mathrm{d}q}{\mathrm{d}t} &= \frac{\partial H}{\partial p_1} = v \\
-\frac{\mathrm{d}v}{\mathrm{d}t} &= \frac{\partial H}{\partial p_2} = -\omega^2 q \\
-\frac{\mathrm{d}\omega}{\mathrm{d}t} &= 0 \quad \text{(constant parameter)} \\
-\frac{\mathrm{d}p_1}{\mathrm{d}t} &= -\frac{\partial H}{\partial q} = \omega^2 p_2 \\
-\frac{\mathrm{d}p_2}{\mathrm{d}t} &= -\frac{\partial H}{\partial v} = -p_1 \\
-\frac{\mathrm{d}p_\omega}{\mathrm{d}t} &= -\frac{\partial H}{\partial \omega} = 2\omega q p_2
-\end{aligned}
-```
-
-For a Mayer cost $g(\omega) = \omega^2$, the transversality condition for the variable parameter is $p_\omega(t_f) - p_\omega(t_0) = -\partial g/\partial \omega = -2\omega$; assuming $p_\omega(t_0) = 0$:
-
-```math
-p_\omega(t_f) = -\int_{t_0}^{t_f} \frac{\partial H}{\partial \omega}(t, x(t), p(t), \omega) \, \mathrm{d}t = -2\omega
-```
-
-```@example main-harmonic
-f = Flow(ocp)
-nothing # hide
-```
-
-The shooting function enforces: $q(t_f) = 0$ (final condition), $p_2(t_f) = 0$ (free final velocity), and $p_\omega(t_f) + 2\omega = 0$ (Mayer-cost transversality). With `variable_costate=true`, the flow returns $(x(t_f), p(t_f), p_\omega(t_f))$, with $p_\omega(t_0) = 0$ by construction:
-
-```@example main-harmonic
-function shoot!(s, p0, ω)
-    x_tf, p_tf, pω_tf = f(t0, [q0, v0], p0, tf; variable=ω, variable_costate=true)
-    q_tf = x_tf[1]
-    pv_tf = p_tf[2]
-    s[1] = q_tf         # q(tf) = 0
-    s[2] = pv_tf        # p2(tf) = 0 (free final velocity)
-    s[3] = pω_tf + 2ω   # pω(tf) + 2ω = 0 (Mayer cost transversality)
-    return nothing
-end
-
-nle!(s, y, _) = shoot!(s, y[1:2], y[3])
-nothing # hide
-```
-
-```@example main-harmonic
-p_direct = costate(direct_sol)
-ω_direct = variable(direct_sol)
-
-p0_guess = p_direct(t0)
-ω_guess = ω_direct
-
-prob_indirect = NonlinearProblem(nle!, [p0_guess..., ω_guess])
-shooting_sol = solve(prob_indirect; show_trace=Val(false))
-p0_sol, ω_sol = shooting_sol.u[1:2], shooting_sol.u[3]
-
-println("Indirect solution:")
-println("Initial costate: p0 = ", p0_sol)
-println("Parameter: ω = ", ω_sol)
-nothing # hide
-```
-
-```@example main-harmonic
-indirect_sol = f((t0, tf), [q0, v0], p0_sol; variable=ω_sol)
-plot!(plt, indirect_sol, :state; linestyle=:dash, lw=2, label="Indirect", color=2)
-```
-
-The direct and indirect solutions match closely, both finding the optimal pulsation $\omega \approx \pi/2$.
+Both the direct and indirect solutions of this one are in
+[Parameter estimation without a control](@ref examples-control-free).
 
 ## How the package knows
 
@@ -353,7 +127,7 @@ To turn either of these examples into a controlled problem, declare a control an
   law and so no pseudo-Hamiltonian to carry a $\mu \cdot g$ term. Use
   `Flow(ocp, law; constraint=…, multiplier=…)` instead.
 
-See [Parameter estimation without a control](@ref examples-control-free) for a worked example
+See [Control and variable together](@ref examples-control-and-variable) for a worked example
 with both.
 
 ## See also
@@ -361,4 +135,5 @@ with both.
 - [Formulation](@ref modelling-formulation) — the control-free case, $m=0$.
 - [Abstract syntax (`@def`)](@ref modelling-abstract-syntax) — the control-free syntax.
 - [Functional API](@ref modelling-functional-api) — the control-free functional-API form.
+- [Parameter estimation without a control](@ref examples-control-free) — both problems above, direct **and** indirect, in full.
 - [From an OCP](@ref flows-from-ocp) — building flows in general.


### PR DESCRIPTION
## What

The two remaining un-rewritten pages of `docs/src/modelling/`. **Phase E2** of the
documentation campaign — this is cutting, not rewriting.

- **`inspect.md`** (637 l.) carried **7 hand-maintained `### Summary table` sections** (~58
  rows of signatures and return types) that duplicate what the generated API reference
  already produces. Nothing tested them, so they drift. Same defect in another shape: 4
  identical `!!! note "Tuple structure"` blocks, 6 `!!! note "Variant methods"` blocks
  listing `is_*` aliases.
- **`without-control.md`** (364 l.) is a *modelling* guide, but it re-played the same two
  problems **direct + indirect** (augmented-Hamiltonian derivations, shooting) that
  `examples/control-free.md` already works in full.

## Changes (documentation only — no API change)

### `inspect.md` — 637 → 326

- Delete the 7 `### Summary table` sections. One opening note links to the
  [Problem API reference](@ref api-problem), where every accessor is listed with its
  signature and return type (same pattern `solve/choosing-a-method.md` already uses for
  `@ref api-options`).
- The 4 "Tuple structure" notes → **one**; the 6 "Variant methods" notes → **one** opening
  note.
- Group related accessor calls into shared ` ```@repl ` blocks (`state_name` /
  `state_dimension` / `state_components` together, the time-name and time-predicate
  families, …) — presentation only, section order unchanged.
- Time-dependence section: 3 near-identical `@example` blocks → 2.
- Kept: every executed accessor call, the `time` vs `times` trap section, "See also".

### `without-control.md` — 364 → 139

- Keep the guide: "what this is for", "how to declare it" + the `control!(pre, 0)` warning,
  **both `@def` definitions** (they show the control-free syntax), **one** direct solve
  (growth) with its plot, "how the package knows", the two `Flow` guards, "See also".
- Cut the two indirect shootings and the augmented-Hamiltonian derivations — deferred to
  [`examples/control-free.md`](@ref examples-control-free), linked from three places.
- `using OrdinaryDiffEq` (the one page still outside the `OrdinaryDiffEqTsit5` convention)
  is removed along with the indirect section.

## Verification

Full docs build (`julia --project=. docs/make.jl`) clean — no `failed to run`, no dangling
`@ref` (the deleted `modelling-inspect-summary-*` anchors had zero inbound links, checked).
The two `@repl` error demos in `inspect.md` (`final_time(ocp)`, `mayer(ocp)`) render clean
`PreconditionError` boxes. Only warnings are the pre-existing `warnonly` external-link ones.
Add the `run documentation` label to build the site in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)