### PR TITLE
docs: start the left sidebar with every group collapsed

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -50,6 +50,26 @@ using Plots
 # "Plot image format — SVG vs PNG".
 Base.showable(::MIME"image/png", ::Plots.Plot) = false
 
+# DocumenterVitepress (0.3.5) hard-codes `collapsed: false` on every sidebar group
+# (`vitepress_config.jl`'s `pagelist2str` for a nested `name => children` entry), so the
+# whole navigation tree renders fully expanded and there is no `MarkdownVitepress` option
+# to change it. Override that one method to emit `collapsed: true` for the sidebar: each
+# group starts folded, and VitePress still auto-expands the group containing the current
+# page. The navbar branch (`sidenav === Val(:navbar)`) is left untouched.
+@eval DocumenterVitepress function pagelist2str(
+    doc, name_contents::Pair{<:AbstractString,<:AbstractArray}, sidenav::Val
+)
+    name, contents = name_contents
+    rendered_contents = String[]
+    for content in contents
+        str = pagelist2str(doc, content, sidenav)
+        isempty(str) || push!(rendered_contents, "{" * str * "}")
+    end
+    final_contents = join(rendered_contents, ",\n")
+    collapse = sidenav === Val(:sidebar) ? "collapsed: true," : ""
+    return "text: '$(replace(name, "'" => "\\'"))', $collapse items: [\n$(final_contents)\n]"
+end
+
 #
 function _ext(pkg, sym)
     m = Base.get_extension(pkg, sym)


### PR DESCRIPTION
## What

The left navigation sidebar renders with **every group expanded**, so the reader scrolls
past the full page tree of every section to reach the one they are in.

DocumenterVitepress 0.3.5 hard-codes `collapsed: false` on each sidebar group
(`vitepress_config.jl`'s `pagelist2str` for a nested `name => children` entry) and exposes
**no `MarkdownVitepress` option** to change it.

## Change

`docs/make.jl` overrides that one method (`@eval DocumenterVitepress function pagelist2str(
doc, ::Pair{<:AbstractString,<:AbstractArray}, sidenav::Val)`) to emit `collapsed: true`
for the **sidebar** branch only — the navbar branch (`Val(:navbar)`) is untouched.

Result: every sidebar group starts folded; VitePress still auto-expands the group that
contains the current page, so context is not lost.

Sits next to the existing `Base.showable(::MIME"image/png", ::Plots.Plot)` DocumenterVitepress
workaround in the same file.

## Verification

Full docs build (`julia --project=. docs/make.jl`) — exit 0, no `failed to run`. The
generated `docs/build/.documenter/.vitepress/config.mts` now carries `collapsed: true` on
all 8 groups (was `false` on all 8). Add the `run documentation` label to preview the site.

## Note

This is a private-API override. If DocumenterVitepress later adds a real option (or changes
`pagelist2str`'s signature), replace this block. Worth a short upstream feature request for
a `sidebar_collapsed` kwarg on `MarkdownVitepress`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)