### PR TITLE
docs: align guides with their examples (Phase E3)

### DIFF
--- a/docs/src/flows/constrained-arcs.md
+++ b/docs/src/flows/constrained-arcs.md
@@ -20,17 +20,23 @@ unconstrained arc, boundary arc (where the constraint is tight and pins down bot
 and the multiplier in feedback form), unconstrained arc again. The boundary arc's flow needs
 that extra structure.
 
+The full three-arc problem — including the shooting that finds the entry and exit times — is
+worked end to end in [State constraint](@ref examples-state-constraint), on this exact OCP.
+This page stays with the boundary arc's flow in isolation.
+
 ```@example main
 t0 = 0.0
 tf = 1.0
 x0 = [-1.0, 0.0]
-VMAX = 1.2
+xf = [0.0, 0.0]
+VMAX = 1.0        # the unconstrained transfer peaks at v = 1.5, so this bound bites
 
 ocp = @def begin
     t ∈ [t0, tf], time
     x = (q, v) ∈ R², state
     u ∈ R, control
     x(t0) == x0
+    x(tf) == xf
     v(t) + 0.0 ≤ VMAX, (vmax)
     ẋ(t) == [v(t), u(t)]
     0.5∫(u(t)^2) → min
@@ -41,13 +47,17 @@ nothing # hide
 ## Building the constrained flow
 
 ```@example main
-g(x) = VMAX - x[2]      # ≥ 0 while the constraint holds
-μ(x, p) = p[1]           # multiplier in feedback form on the boundary
-law(x, p) = 0.0           # control on the boundary arc
+g(x) = VMAX - x[2]      # ≥ 0 away from the boundary, 0 on it
+μ(x, p) = p[1]           # feedback multiplier on the boundary arc: μ = p_q
+law(x, p) = 0.0           # the boundary control: u = 0 keeps v̇ = 0, holding v at VMAX
 
 f_boundary = Flow(ocp, law; constraint=(x, u) -> g(x), multiplier=μ)
-xf, pf = f_boundary(t0, x0, [12.0, 6.0], tf)
-xf
+
+# integrate a segment of the boundary arc: enter at t1 with v = VMAX
+t1, t2 = 0.3, 0.7
+p1 = [1.0, 0.4]
+xb, pb = f_boundary(t1, [-0.5, VMAX], p1, t2)
+xb, g(xb)                # v held at VMAX along the arc → g(xb) ≈ 0
 ```
 
 `constraint=`/`multiplier=` must be given **as a pair** — one without the other is rejected:
@@ -69,7 +79,7 @@ for the other shapes) — equivalent, more explicit:
 
 ```@example main
 f_typed = Flow(ocp, law; constraint=StateConstraint(g), multiplier=μ)
-f_typed(t0, x0, [12.0, 6.0], tf)[1] ≈ xf
+f_typed(t1, [-0.5, VMAX], p1, t2)[1] ≈ xb
 ```
 
 **A `Symbol` naming a `:path` constraint already declared in the OCP** — the standout
@@ -101,14 +111,32 @@ end # hide
 ## Several constraints at once
 
 Pass matched tuples of functions (or labels) and multipliers, one per active constraint on the
-boundary arc, in place of the single values above.
+boundary arc, in place of the single values above:
+
+```@example main
+g_q(x) = 10.0 - x[1]                       # a second bound, q ≤ 10 — slack on this arc
+f_two = Flow(ocp, law;
+             constraint = ((x, u) -> g(x), (x, u) -> g_q(x)),
+             multiplier = (μ, (x, p) -> 0.0))
+f_two(t1, [-0.5, VMAX], p1, t2)[1] ≈ xb    # same arc: the extra constraint contributes nothing
+```
 
 ## Assembling the arcs
 
 A boundary arc is one phase in a larger [multi-phase flow](@ref flows-multi-phase):
 unconstrained arc, then the constrained flow from `t1` (constraint activation), then
 unconstrained again from `t2` (exit) — with a jump on the costate at each switch if the
-constraint order requires one.
+constraint order requires one (none here: a first-order constraint keeps the costate
+continuous).
+
+```@example main
+f_interior = Flow(ocp, (x, p) -> p[2])                  # u = p_v away from the boundary
+φ = f_interior * (t1, f_boundary) * (t2, f_interior)    # unconstrained · boundary · unconstrained
+n_phases(φ)
+```
+
+Solving for `t1` and `t2` rather than fixing them is the shooting problem worked in
+[State constraint](@ref examples-state-constraint).
 
 ## Positional form is gone
 
@@ -150,3 +178,5 @@ end # hide
   into one callable flow.
 - [Writing a shooting function](@ref flows-shooting) — solving for the switching times
   themselves rather than assuming them known.
+- [State constraint](@ref examples-state-constraint) — this OCP worked end to end: the
+  three-arc structure, the costate jump, and the shooting for the entry and exit times.

--- a/docs/src/flows/shooting.md
+++ b/docs/src/flows/shooting.md
@@ -51,25 +51,12 @@ f_min = Flow(ocp, (x, p, v) -> u_min)
 nothing # hide
 ```
 
-## A simple shooting function
+## The shooting function
 
-The simplest case has no switching — a single arc, fixed time. Out-of-place, the residual is
-just the target-state gap:
-
-```@example main
-function shoot_simple(p0)
-    xf_, _ = f_max(t0, x0, p0, 1.0; variable=2.0)   # arbitrary tf here — illustration only
-    return xf_ - xf
-end
-nothing # hide
-```
-
-## In-place, for the solver
-
-The real problem has 4 unknowns — $p_0$ (2), the switching time $t_1$, and $t_f$ — and 4
+The problem has 4 unknowns — $p_0$ (2), the switching time $t_1$, and $t_f$ — and 4
 residuals: the target state (2), the switching condition ($p_2=0$ where the bang-bang control
 switches, since $H_u=0$ there), and the free-time transversality $H(t_f)=-1$ (the Mayer cost is
-$t_f\to\min$, normal case):
+$t_f\to\min$, normal case). Written in place, the way `NonlinearSolve` wants it:
 
 ```@example main
 H(x, p, u) = p[1] * x[2] + p[2] * u - 1
@@ -139,9 +126,9 @@ xf_v, pf_v, pvf = f_max(t0, x0, [1.0, 1.0], 1.0; variable=2.0, variable_costate=
 pvf
 ```
 
-## Multiple shooting and switching times
+## Switching times as unknowns
 
-The example above already has one: $t_1$ is an unknown alongside $p_0$ and $t_f$. Each
+The example above already carries one: $t_1$ is solved for alongside $p_0$ and $t_f$. Each
 additional switch adds one more unknown time and one more switching-condition residual — see
 [Multi-phase flows](@ref flows-multi-phase) for concatenating the corresponding flows once the
 times are known (or being solved for).
@@ -160,18 +147,25 @@ p0_guess
 
 ## Checking against the direct solution
 
-```@example main
-objective(direct_sol)
-```
+Rebuild the full bang–bang trajectory from the shooting solution — `f_max`, then `f_min` at
+the solved switch — and read its endpoint (a concatenated flow returns the stacked
+state–costate vector `[q, v, p_q, p_v]` at the final time):
 
 ```@example main
-indirect_sol = f_max((t0, sol.u[3]), x0, sol.u[1:2]; variable=sol.u[4])
-nothing # hide
+p0_sol, t1_sol, tf_sol = sol.u[1:2], sol.u[3], sol.u[4]
+
+f_bb = f_max * (t1_sol, f_min)
+zf = f_bb(t0, x0, p0_sol, tf_sol; variable=tf_sol)
+
+zf[1:2]     # the final state ≈ [0, 0] — the indirect solution hits the target
 ```
 
-Compare `state(indirect_sol)`/`objective`-derived quantities against the direct solve the same
-way [Solution object](@ref results-solution) already teaches — both describe the same optimal
-trajectory, found by two different methods.
+The two methods agree on the optimum. The cost here is the final time, so comparing objectives
+is comparing $t_f$:
+
+```@example main
+tf_sol, objective(direct_sol)
+```
 
 ## See also
 

--- a/docs/src/results/plot.md
+++ b/docs/src/results/plot.md
@@ -5,13 +5,8 @@ Draft = false
 ```
 
 `plot`/`plot!` extend [Plots.jl](https://docs.juliaplots.org) to draw a [`Solution`](@ref results-solution)
-directly — the same call works on a `Flow`-produced trajectory too (last section below).
-
-```@docs; canonical=false
-plot(::CTModels.Solution, ::Symbol...)
-plot!(::CTModels.Solution, ::Symbol...)
-plot!(::Plots.Plot, ::CTModels.Solution, ::Symbol...)
-```
+directly — the same call works on a `Flow`-produced trajectory too (last section below). The
+full signatures are collected under [Reference](@ref results-plot-reference) at the end.
 
 ## Getting started
 
@@ -287,6 +282,14 @@ fine_grid = range(t0, tf, 100)
 f2 = Flow(ocp, (x, p) -> p[2]; saveat=fine_grid, dense=false)
 sol_flow2 = f2((t0, tf), x0, p0)
 plot(sol_flow2)
+```
+
+## [Reference](@id results-plot-reference)
+
+```@docs; canonical=false
+plot(::CTModels.Solution, ::Symbol...)
+plot!(::CTModels.Solution, ::Symbol...)
+plot!(::Plots.Plot, ::CTModels.Solution, ::Symbol...)
 ```
 
 ## See also


### PR DESCRIPTION
## Phase E3 of the documentation campaign

Since the Examples section exists, several guides improvised half a demonstration where the example next door does the whole job — and without linking to it. A guide should teach the shape and hand off, not carry a degenerate version of a worked problem.

Plan: `.reports/campaign/E3-guides-examples.md`. Editorial calls settled with the maintainer beforehand (recorded in that file).

### `docs/src/flows/constrained-arcs.md`
- OCP gains `x(tf) == xf` and `VMAX` drops `1.2 → 1.0` (the unconstrained transfer peaks at `v = 1.5`, so the bound now genuinely activates).
- The boundary-flow demo integrates a real boundary-arc segment (`f_boundary(t1, [-0.5, VMAX], p1, t2)` → `g(xb) == 0.0`) instead of `law = 0` over the whole horizon from a point where the constraint never activates.
- Links to `examples/state-constraint.md` (the worked three-arc shooting) — added in "The setting" and "See also". Its absence was the core of the finding.
- "Several constraints at once" and "Assembling the arcs" were prose only; both get short executable snippets (tuple `constraint`/`multiplier`; `f_interior * (t1, f_boundary) * (t2, f_interior)` → `n_phases == 3`).

### `docs/src/flows/shooting.md`
- `shoot_simple` deleted — it announced itself as "illustration only" and was never reused.
- The direct/indirect comparison is finished: rebuild the full bang–bang flow `f_max * (t1_sol, f_min)`, check the endpoint (`≈ [0, 0]`) and objective (`tf_sol ≈ objective(direct_sol) ≈ 2`) against the direct solve.
- "Multiple shooting and switching times" → "Switching times as unknowns" (the section carries no multiple shooting; the example already solves for `t1`).

### `docs/src/results/plot.md`
- The `@docs` block moves off the page top into a `## Reference` section (`@id results-plot-reference`) just above "See also". No page opens with a function signature.

## Verification

Full `julia --project=. docs/make.jl`: exit 0, **0** unresolved `@ref`, **0** failed `@example` blocks. The 4 `@extref` warnings in the log are the unchanged Phase-D upstream backlog under `warnonly`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)