### PR TITLE
docs: coherence pass — one name per page + small fixes (Phase E4 part 1)

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -289,7 +289,7 @@ with_api_reference(src_dir, ext_dir) do api_pages
             # index.md is the VitePress root — not listed here
             "Getting started" => [
                 "Installation" => "getting-started/installation.md",
-                "First problem" => "getting-started/first-problem.md",
+                "Your first problem" => "getting-started/first-problem.md",
                 "Guided tour" => "getting-started/guided-tour.md",
             ],
             "Modelling" => [
@@ -319,22 +319,22 @@ with_api_reference(src_dir, ext_dir) do api_pages
                 "From Hamiltonians" => "flows/from-hamiltonians.md",
                 "Simulation" => "flows/simulation.md",
                 "Accessors" => "flows/accessors.md",
-                "Multi-phase" => "flows/multi-phase.md",
+                "Multi-phase flows" => "flows/multi-phase.md",
                 "Constrained arcs" => "flows/constrained-arcs.md",
                 "Shooting" => "flows/shooting.md",
             ],
             "Geometry" => [
                 "Overview" => "geometry/overview.md",
                 "Lift" => "geometry/lift.md",
-                "ad" => "geometry/ad.md",
-                "Poisson" => "geometry/poisson.md",
-                "@Lie" => "geometry/lie-macro.md",
+                "Lie derivative and Lie bracket" => "geometry/ad.md",
+                "Poisson bracket" => "geometry/poisson.md",
+                "The @Lie macro" => "geometry/lie-macro.md",
                 "AD backend" => "geometry/ad-backend.md",
             ],
             "Examples" => [
-                "Gallery" => "examples/gallery.md",
+                "Example gallery" => "examples/gallery.md",
                 "Energy minimisation" => "examples/double-integrator-energy.md",
-                "Time minimisation (bang-bang)" => "examples/double-integrator-time.md",
+                "Time minimisation (bang–bang)" => "examples/double-integrator-time.md",
                 "Parameter estimation without a control" => "examples/control-free.md",
                 "Control and variable together" => "examples/control-and-variable.md",
                 "Singular control" => "examples/singular-control.md",

--- a/docs/reports/00-cahier-des-charges.md
+++ b/docs/reports/00-cahier-des-charges.md
@@ -420,7 +420,10 @@ after the three assertions in `test/suite/reexport/test_ctlie.jl:81-84` are rewr
 - [ ] `docs/Project.toml` resolves against the root `Project.toml`.
 - [ ] `docs/make.jl` runs with `draft = false`, log clean of resolution errors.
 - [ ] No user-facing page contains `Lie(`, ` ⋅ `, `HamiltonianLift`, `OptimalControl.VectorField`,
-      `autonomous=`, `Flow(ocp, u, g,` — except the Migration page, in inert fences.
+      the bare `autonomous=` keyword, or `Flow(ocp, u, g,` — except the Migration page, in inert
+      fences. The `is_autonomous=` spelling and CTModels' `time_dependence!(…; autonomous=…)`
+      (its real current signature) are the supported API and do not count; grep with
+      `grep -nE '(^|[^_])autonomous=' | grep -v time_dependence` to skip both.
 - [ ] Every capability in §6 has a page.
 - [ ] [`99-api-coverage.md`](99-api-coverage.md) has no uncovered re-exported symbol.
 - [ ] `docs/attic/` is gone.

--- a/docs/src/examples/control-free.md
+++ b/docs/src/examples/control-free.md
@@ -5,7 +5,7 @@ Draft = false
 ```
 
 Two problems with no control anywhere — only a `variable` to fit to data. See
-[Problems without a control](@ref modelling-without-control) for the modelling side of this;
+[No control](@ref modelling-without-control) for the modelling side of this;
 this page is the full worked story, direct and indirect, for both.
 
 ```@example main
@@ -188,7 +188,7 @@ plot!(plt_harmonic, indirect_harmonic, :state; label="Indirect", linestyle=:dash
 
 ## See also
 
-- [Problems without a control](@ref modelling-without-control) — the modelling-side guide for
+- [No control](@ref modelling-without-control) — the modelling-side guide for
   control-free problems.
 - [Control and variable together](@ref examples-control-and-variable) — the same two systems,
   with a control added back in.

--- a/docs/src/examples/double-integrator-time.md
+++ b/docs/src/examples/double-integrator-time.md
@@ -118,7 +118,7 @@ plot!(plt, indirect_sol, :state, :control; label="Indirect")
 
 ## See also
 
-- [Multi-phase](@ref flows-multi-phase) — flow concatenation `*`, in general.
+- [Multi-phase flows](@ref flows-multi-phase) — flow concatenation `*`, in general.
 - [Shooting](@ref flows-shooting) — bang–bang shooting, worked in full detail from this exact
   problem.
 - [Energy minimisation](@ref examples-double-integrator-energy) — the same wagon, unbounded

--- a/docs/src/examples/singular-control.md
+++ b/docs/src/examples/singular-control.md
@@ -46,6 +46,11 @@ ocp = @def begin
 end
 ```
 
+The $-\pi/2 \le \theta(t) \le \pi/2$ box only keeps the *direct* solver away from a spurious
+branch where the vehicle turns the long way round; the optimal orientation stays well inside
+it, so the bound is never active at the solution. The *indirect* solution below is built from
+the PMP flow alone and never sees this bound — the two still agree because it is slack.
+
 ## Direct solution
 
 ```@example main
@@ -86,6 +91,17 @@ to a function of the state alone:
 
 ```@example main
 u_indirect(x) = sin(x[3])^2
+```
+
+This is exact on the singular surface $\{H_1 = 0,\ H_{01} = 0\}$ — here $p_\theta = 0$ and
+$p_y = p_x\tan\theta$. Check it against the bracket formula at an arbitrary point of that
+surface:
+
+```@example main
+q_s = [0.3, -0.1, 0.5]
+p_s = [1.7, 1.7 * tan(q_s[3]), 0.0]      # a point of {H₁ = 0, H₀₁ = 0}
+
+us_bracket(q_s, p_s), u_indirect(q_s)    # equal
 ```
 
 ## Indirect solution
@@ -149,12 +165,12 @@ The indirect and direct solutions match closely, confirming the singular-control
 above is correct — and, since `Lift`/`@Lie` needed no change from the pre-rewrite version, that
 the flow half was migrated correctly too.
 
-The bracket formula and the simplified state-only one agree **along this extremal** — not at an
-arbitrary $(q,p)$, only on the trajectory the costate actually produces:
+The same equality, now along the computed extremal rather than a hand-picked surface point:
 
 ```@example main
-[us_bracket(state(indirect_sol)(t), costate(indirect_sol)(t)) - u_indirect(state(indirect_sol)(t))
- for t in range(t0, tf_sol, 5)]
+xs = state(indirect_sol)
+ps = costate(indirect_sol)
+[us_bracket(xs(t), ps(t)) - u_indirect(xs(t)) for t in range(t0, tf_sol, 5)]
 ```
 
 ## See also

--- a/docs/src/examples/state-constraint.md
+++ b/docs/src/examples/state-constraint.md
@@ -48,6 +48,10 @@ ocp = @def begin
 end
 ```
 
+The `+ 0.0` in `v(t) + 0.0 ≤ VMAX` forces the parser to read this as a nonlinear **path**
+constraint (with a dual, reachable by its `:vmax` label) rather than a plain box bound on the
+state — see [Constrained arcs](@ref flows-constrained-arcs).
+
 ### Direct solution
 
 ```@example main
@@ -292,5 +296,5 @@ t1_arc, 3a_arc, t2_arc, 1 - 3a_arc
 
 - [Constrained arcs](@ref flows-constrained-arcs) — `constraint=`/`multiplier=`, the three ways
   to spell the constraint, in general.
-- [Multi-phase](@ref flows-multi-phase) — flow concatenation and costate jumps, in general.
+- [Multi-phase flows](@ref flows-multi-phase) — flow concatenation and costate jumps, in general.
 - [Energy minimisation](@ref examples-double-integrator-energy) — the same wagon, unconstrained.

--- a/docs/src/flows/accessors.md
+++ b/docs/src/flows/accessors.md
@@ -131,6 +131,6 @@ CTFlows.Flows.integrator(f)
 
 - [From an OCP](@ref flows-from-ocp) — the most common source of a flow with all four
   accessors available.
-- [From Hamiltonians and vector fields](@ref flows-from-hamiltonians) — every constructor in
+- [From Hamiltonians](@ref flows-from-hamiltonians) — every constructor in
   the table above, built and shown in full.
 - [Geometry](@ref geometry-overview) — the Lie-theoretic tools these systems are built on.

--- a/docs/src/flows/constrained-arcs.md
+++ b/docs/src/flows/constrained-arcs.md
@@ -44,6 +44,11 @@ end
 nothing # hide
 ```
 
+`v(t) + 0.0 ≤ VMAX` rather than `v(t) ≤ VMAX`: a bare `v(t) ≤ VMAX` parses as a **box bound**
+on the state component, which carries no path multiplier and cannot be pulled into a flow by
+its label. Adding `+ 0.0` makes it a nonlinear **path** constraint — it now has a dual, and
+`constraint=:vmax` below can reach it.
+
 ## Building the constrained flow
 
 ```@example main
@@ -176,7 +181,7 @@ end # hide
 
 - [Multi-phase flows](@ref flows-multi-phase) — assembling several arcs, constrained or not,
   into one callable flow.
-- [Writing a shooting function](@ref flows-shooting) — solving for the switching times
+- [Shooting](@ref flows-shooting) — solving for the switching times
   themselves rather than assuming them known.
 - [State constraint](@ref examples-state-constraint) — this OCP worked end to end: the
   three-arc structure, the costate jump, and the shooting for the entry and exit times.

--- a/docs/src/flows/from-hamiltonians.md
+++ b/docs/src/flows/from-hamiltonians.md
@@ -1,4 +1,4 @@
-# [From Hamiltonians and vector fields](@id flows-from-hamiltonians)
+# [From Hamiltonians](@id flows-from-hamiltonians)
 
 ```@meta
 Draft = false
@@ -154,7 +154,7 @@ isn't.
 
 - [From an OCP](@ref flows-from-ocp) — the same constructors, specialised: an OCP supplies
   $\tilde H$ automatically, you only supply the law.
-- [What you can get back from a flow](@ref flows-accessors) — which accessor works on which of
+- [Accessors](@ref flows-accessors) — which accessor works on which of
   the flows built here.
 - [Lift and Poisson brackets](@ref geometry-lift) — the differential-geometric layer these
   constructors sit on top of.

--- a/docs/src/flows/from-ocp.md
+++ b/docs/src/flows/from-ocp.md
@@ -58,7 +58,7 @@ f_typed(t0, x0, p0, tf)[1] ≈ xf
 
 Two other law kinds exist — `ClosedLoop(x -> ...)` and `OpenLoop(t -> ...)` — but they build a
 *state* flow with no costate, appropriate for simulation rather than indirect solving; see
-[Simulating a controlled system](@ref flows-simulation).
+[Simulation](@ref flows-simulation).
 
 ## Non-autonomous problems
 
@@ -166,7 +166,7 @@ pω
 ## Control-free problems
 
 `Flow(ocp)` — no law argument — works when the problem has no control at all: see
-[Problems without a control](@ref modelling-without-control) for how to declare one and what
+[No control](@ref modelling-without-control) for how to declare one and what
 it means.
 
 ## Total or partial Hamiltonian
@@ -222,12 +222,12 @@ Everything in [Solution object](@ref results-solution) and [Plot](@ref results-p
 verbatim — `state(sol)`, `control(sol)`, `objective(sol)`, `plot(sol)`. This is specific to
 flows built **from an OCP**; a flow built without one (a bare `Hamiltonian`, a
 `ControlledVectorField`, ...) returns its own trajectory wrapper instead — see
-[Simulating a controlled system](@ref flows-simulation) for that distinction.
+[Simulation](@ref flows-simulation) for that distinction.
 
 ## See also
 
-- [What you can get back from a flow](@ref flows-accessors) — the Hamiltonian, its vector
+- [Accessors](@ref flows-accessors) — the Hamiltonian, its vector
   field, and the law you passed in, pulled back out.
-- [Writing a shooting function](@ref flows-shooting) — the payoff: turn this into a root-finding
+- [Shooting](@ref flows-shooting) — the payoff: turn this into a root-finding
   problem for $p_0$.
-- [Problems without a control](@ref modelling-without-control) — the `Flow(ocp)` case in full.
+- [No control](@ref modelling-without-control) — the `Flow(ocp)` case in full.

--- a/docs/src/flows/multi-phase.md
+++ b/docs/src/flows/multi-phase.md
@@ -132,7 +132,7 @@ xf   # ≈ [0, 0], the target
 
 - [Constrained arcs](@ref flows-constrained-arcs) — assembling arcs around a boundary arc
   specifically, where the jump usually comes from a costate discontinuity.
-- [Writing a shooting function](@ref flows-shooting) — solving for the switching time(s)
+- [Shooting](@ref flows-shooting) — solving for the switching time(s)
   themselves, not just assuming them known as here.
 - [From an OCP](@ref flows-from-ocp) — the single-arc case this section generalises.
 - [Time minimisation (bang–bang)](@ref examples-double-integrator-time) — the full story behind

--- a/docs/src/flows/overview.md
+++ b/docs/src/flows/overview.md
@@ -51,14 +51,14 @@ numerically.
 ## Three things this section does
 
 1. **Indirect solving** — [From an OCP](@ref flows-from-ocp),
-   [Constrained arcs](@ref flows-constrained-arcs), [Multi-phase](@ref flows-multi-phase),
+   [Constrained arcs](@ref flows-constrained-arcs), [Multi-phase flows](@ref flows-multi-phase),
    [Shooting](@ref flows-shooting).
-2. **Simulation** — [Simulating a controlled system](@ref flows-simulation): integrate under a
+2. **Simulation** — [Simulation](@ref flows-simulation): integrate under a
    given control, no optimization involved.
-3. **Inspection** — [What you can get back from a flow](@ref flows-accessors): the Hamiltonian,
+3. **Inspection** — [Accessors](@ref flows-accessors): the Hamiltonian,
    its vector field, the pseudo-Hamiltonian, the control law you passed in.
 
-[From Hamiltonians and vector fields](@ref flows-from-hamiltonians) covers the lower-level
+[From Hamiltonians](@ref flows-from-hamiltonians) covers the lower-level
 constructors these three jobs are all built from.
 
 ## Before you start
@@ -150,12 +150,12 @@ f(t0, x0, p0, tf; method=:gpu)    # wrong — MethodError, no such call-time key
 ## Where to go
 
 - [From an OCP](@ref flows-from-ocp) — the main path for indirect optimal control.
-- [From Hamiltonians and vector fields](@ref flows-from-hamiltonians) — building blocks below
+- [From Hamiltonians](@ref flows-from-hamiltonians) — building blocks below
   the OCP layer.
-- [Simulating a controlled system](@ref flows-simulation) — no optimization, just integration.
-- [What you can get back from a flow](@ref flows-accessors) — inspection.
+- [Simulation](@ref flows-simulation) — no optimization, just integration.
+- [Accessors](@ref flows-accessors) — inspection.
 - [Multi-phase flows](@ref flows-multi-phase) and [Constrained arcs](@ref flows-constrained-arcs)
   — assembling several arcs into one trajectory.
-- [Writing a shooting function](@ref flows-shooting) — the payoff.
+- [Shooting](@ref flows-shooting) — the payoff.
 - [Solve overview](@ref solve-overview) — the direct-method counterpart to everything here.
 - [Geometry](@ref geometry-overview) — the Lie-theoretic tools some of these constructors build on.

--- a/docs/src/flows/shooting.md
+++ b/docs/src/flows/shooting.md
@@ -1,4 +1,4 @@
-# [Writing a shooting function](@id flows-shooting)
+# [Shooting](@id flows-shooting)
 
 ```@meta
 Draft = false
@@ -84,7 +84,7 @@ sqrt(sum(abs2, s))
 ```@example main
 ξ_guess = [1.0, 1.0, 1.0, 2.0] .* 1.1
 prob = NonlinearProblem((s, ξ, _) -> shoot!(s, ξ), ξ_guess)
-sol = solve(prob, SimpleNewtonRaphson(); abstol=1e-10, reltol=1e-10)
+sol = NonlinearSolve.solve(prob, SimpleNewtonRaphson(); abstol=1e-10, reltol=1e-10)
 sol.u, sol.retcode
 ```
 

--- a/docs/src/flows/simulation.md
+++ b/docs/src/flows/simulation.md
@@ -138,5 +138,5 @@ never name it in your own code, only call the generic accessors on it.
   above, in full.
 - [From an OCP](@ref flows-from-ocp) — the indirect-solving counterpart, where the law comes
   from the PMP instead of being handed to you.
-- [Problems without a control](@ref modelling-without-control) — control-free problems, a
+- [No control](@ref modelling-without-control) — control-free problems, a
   related but distinct case.

--- a/docs/src/geometry/ad-backend.md
+++ b/docs/src/geometry/ad-backend.md
@@ -1,4 +1,4 @@
-# [Choosing an AD backend](@id geometry-ad-backend)
+# [AD backend](@id geometry-ad-backend)
 
 ```@meta
 Draft = false
@@ -30,8 +30,9 @@ keyword is given.
 ## Changing it globally
 
 ```@example main
-import CTBase: Differentiation
+using CTBase: Differentiation
 
+default_backend = dg_ad_backend()   # keep the default, to restore it below
 dg_ad_backend!(Differentiation.DifferentiationInterface())
 dg_ad_backend()
 ```
@@ -54,7 +55,7 @@ A GPU-parameterized backend is constructed the same way, with the `GPU` strategy
 `CPU`:
 
 ```julia
-import CTBase: Differentiation, Strategies
+using CTBase: Differentiation, Strategies
 
 dg_ad_backend!(Differentiation.DifferentiationInterface{Strategies.GPU}())
 ```
@@ -66,6 +67,16 @@ environment or in CI, the same caveat as [GPU](@ref solve-gpu) on the solve side
 
 ```@example main
 describe(:di)
+```
+
+## Restoring the default
+
+`dg_ad_backend!` is global and persists for the rest of the session — set it back when the
+demonstration is over:
+
+```@example main
+dg_ad_backend!(default_backend)
+dg_ad_backend()
 ```
 
 ## If nothing works

--- a/docs/src/geometry/lie-macro.md
+++ b/docs/src/geometry/lie-macro.md
@@ -94,12 +94,12 @@ them directly, but because `@Lie`'s expansion needs them in scope.
 The old `autonomous=`/`variable=` keywords are rejected at macro-expansion time, not silently
 accepted:
 
-```@repl main
-try # hide
-eval(:(@Lie [$F1, $F2] autonomous=false))
-catch e # hide
-showerror(IOContext(stdout, :color => false), e) # hide
-end # hide
+```julia
+julia> @Lie [F1, F2] autonomous=false
+ERROR: IncorrectArgument: @Lie: unknown keyword argument
+Got       autonomous
+Expected  is_autonomous, is_variable, or ad_backend
+Context   @Lie macro keyword parsing
 ```
 
 ## See also

--- a/docs/src/geometry/lift.md
+++ b/docs/src/geometry/lift.md
@@ -85,7 +85,7 @@ Hv([1.0, 2.0], [3.0, 4.0], 1.0)   # H(x, p, v)
 Feed a lift straight into [`Poisson`](@ref) (see
 [The bridge identity](@ref geometry-overview)), or into [`Flow`](@ref) to integrate the
 associated Hamiltonian system — see
-[From Hamiltonians and vector fields](@ref flows-from-hamiltonians).
+[From Hamiltonians](@ref flows-from-hamiltonians).
 
 ## A trap to know about
 
@@ -109,5 +109,5 @@ it. Harmless, but don't be thrown by it: the operation that actually failed is `
 
 - [Overview](@ref geometry-overview) — the bridge identity this page is one half of.
 - [Poisson bracket](@ref geometry-poisson) — what a lift is usually fed into.
-- [From Hamiltonians and vector fields](@ref flows-from-hamiltonians) — turning a lift into a
+- [From Hamiltonians](@ref flows-from-hamiltonians) — turning a lift into a
   flow.

--- a/docs/src/geometry/overview.md
+++ b/docs/src/geometry/overview.md
@@ -66,7 +66,7 @@ autonomous, one not, say — throw a `PreconditionError` naming both traits expl
 
 Everything here is AD-backed **except `Lift`**, which is a purely algebraic rearrangement
 ($H(x,p) = p \cdot X(x)$, no derivative involved). See
-[Choosing an AD backend](@ref geometry-ad-backend) for how the derivatives themselves are
+[AD backend](@ref geometry-ad-backend) for how the derivatives themselves are
 computed and how to change the backend.
 
 ## Coming from v2.0
@@ -86,4 +86,4 @@ catch the old names.
 - [Lie derivative and Lie bracket](@ref geometry-ad)
 - [Poisson bracket](@ref geometry-poisson)
 - [The `@Lie` macro](@ref geometry-lie-macro)
-- [Choosing an AD backend](@ref geometry-ad-backend)
+- [AD backend](@ref geometry-ad-backend)

--- a/docs/src/getting-started/first-problem.md
+++ b/docs/src/getting-started/first-problem.md
@@ -36,7 +36,7 @@ end
 nothing # hide
 ```
 
-See [Abstract syntax](@ref modelling-abstract-syntax) for what each line above means.
+See [Abstract syntax (`@def`)](@ref modelling-abstract-syntax) for what each line above means.
 
 ## Solve it
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -47,7 +47,7 @@ plot(sol)
 
 | Section | What's there |
 | --- | --- |
-| [Getting started](@ref getting-started-guided-tour) | Install, solve your first problem, then a longer guided tour covering both the direct and indirect methods. |
+| [Getting started](@ref getting-started-installation) | Install, solve your first problem, then a longer guided tour covering both the direct and indirect methods. |
 | [Modelling](@ref modelling-formulation) | The `@def` DSL, the macro-free functional API, control-free (parameter estimation) problems, and problem introspection. |
 | [Solve (direct)](@ref solve-overview) | Discretize-and-transcribe methods: choosing a strategy, initial guesses, options, explicit mode, GPU. |
 | [Results](@ref results-solution) | Read a `Solution` — trajectories, costate, duals, status — plot it, save it, reload it. |

--- a/docs/src/modelling/abstract-syntax.md
+++ b/docs/src/modelling/abstract-syntax.md
@@ -1,4 +1,4 @@
-# [Abstract syntax](@id modelling-abstract-syntax)
+# [Abstract syntax (`@def`)](@id modelling-abstract-syntax)
 
 ```@meta
 Draft = false
@@ -222,7 +222,7 @@ nothing # hide
 There is no dedicated syntax for "no control": omitting the control declaration entirely *is*
 the syntax — do not declare a dummy `u ∈ R, control` with `u(t) == 0`, and never write
 `control!(pre, 0)` on the [functional API](@ref modelling-functional-api), which is rejected
-as an error. See [Problems without a control](@ref modelling-without-control) for the full
+as an error. See [No control](@ref modelling-without-control) for the full
 worked examples above, solved both directly and indirectly.
 
 ## [Dynamics](@id modelling-abstract-syntax-dynamics)
@@ -740,5 +740,5 @@ nothing # hide
 
 - [Formulation](@ref modelling-formulation) — the mathematics this syntax encodes.
 - [Functional API](@ref modelling-functional-api) — build the same model without the macro.
-- [Problems without a control](@ref modelling-without-control) — the control-free case, worked in full.
+- [No control](@ref modelling-without-control) — the control-free case, worked in full.
 - [Inspect a problem](@ref modelling-inspect) — read a built model back.

--- a/docs/src/modelling/formulation.md
+++ b/docs/src/modelling/formulation.md
@@ -55,10 +55,10 @@ v_{\mathrm{lower}} \le v \le v_{\mathrm{upper}}.
 
 ## The control-free case
 
-Nothing above requires a control to be present: taking $m = 0$ (no $u$) is a legitimate degenerate case, used to fit or optimise parameters of a dynamical system rather than to steer it. See [Problems without a control](@ref modelling-without-control) for how to declare and solve such problems.
+Nothing above requires a control to be present: taking $m = 0$ (no $u$) is a legitimate degenerate case, used to fit or optimise parameters of a dynamical system rather than to steer it. See [No control](@ref modelling-without-control) for how to declare and solve such problems.
 
 ## See also
 
 - [Abstract syntax (`@def`)](@ref modelling-abstract-syntax) — write this formulation directly as Julia code.
 - [Functional API](@ref modelling-functional-api) — build the same model without the macro.
-- [Problems without a control](@ref modelling-without-control) — the $m = 0$ case.
+- [No control](@ref modelling-without-control) — the $m = 0$ case.

--- a/docs/src/modelling/functional-api.md
+++ b/docs/src/modelling/functional-api.md
@@ -117,7 +117,7 @@ ocp = build(pre)
 
 ## A worked example: double integrator, energy minimisation
 
-The simplest case: fixed time interval, boundary constraints, autonomous dynamics, Lagrange cost. The [`@def`](@ref) abstract syntax is shown on the left and the equivalent functional API on the right. See the [example gallery](@ref examples-gallery) for more problems worked both ways, including a control-free one (see also [Problems without a control](@ref modelling-without-control)).
+The simplest case: fixed time interval, boundary constraints, autonomous dynamics, Lagrange cost. The [`@def`](@ref) abstract syntax is shown on the left and the equivalent functional API on the right. See the [example gallery](@ref examples-gallery) for more problems worked both ways, including a control-free one (see also [No control](@ref modelling-without-control)).
 
 ```@example ex-energy
 using OptimalControl
@@ -253,7 +253,7 @@ This is the one place on the site where this is spelled out; every other page ju
 - `variable!` → before `time!` when using free-time indices (`indf`, `ind0`)
 - `variable!` → before `dynamics!` and `objective!`
 - `dynamics!` and `objective!` → after `time!` and `state!`
-- `control!` is optional and, when used, has no ordering constraint of its own beyond needing `state!` first (component-count validation) — see [Problems without a control](@ref modelling-without-control) for what omitting it means.
+- `control!` is optional and, when used, has no ordering constraint of its own beyond needing `state!` first (component-count validation) — see [No control](@ref modelling-without-control) for what omitting it means.
 
 ## Equivalence
 
@@ -263,5 +263,5 @@ The abstract and functional forms are not just "meant to agree" — it's a teste
 
 - [Formulation](@ref modelling-formulation) — the mathematics this API builds.
 - [Abstract syntax (`@def`)](@ref modelling-abstract-syntax) — the macro alternative.
-- [Problems without a control](@ref modelling-without-control) — omitting `control!` entirely.
+- [No control](@ref modelling-without-control) — omitting `control!` entirely.
 - [Inspect a problem](@ref modelling-inspect) — read a built model back.

--- a/docs/src/modelling/inspect.md
+++ b/docs/src/modelling/inspect.md
@@ -160,7 +160,7 @@ dim_control_constraints_box(ocp)
 has_control(ocp)  # true if the problem has a control input
 ```
 
-`is_control_free(ocp) ≡ !has_control(ocp)` — see [Problems without a control](@ref modelling-without-control).
+`is_control_free(ocp) ≡ !has_control(ocp)` — see [No control](@ref modelling-without-control).
 
 ## Variable
 

--- a/docs/src/solve/choosing-a-method.md
+++ b/docs/src/solve/choosing-a-method.md
@@ -14,7 +14,7 @@ any one piece before you commit to it.
   Only `:collocation` exists today.
 - **Modeler** — how the resulting NLP is built: `:adnlp` (automatic differentiation via
   ADNLPModels) or `:exa` (SIMD-friendly, GPU-capable, via ExaModels — only for problems whose
-  dynamics are written coordinatewise, see [Abstract syntax](@ref modelling-abstract-syntax)).
+  dynamics are written coordinatewise, see [Abstract syntax (`@def`)](@ref modelling-abstract-syntax)).
 - **Solver** — which NLP solver runs: `:ipopt`, `:madnlp`, `:uno`, `:madncl`, `:knitro`.
 - **Parameter** — execution backend: `:cpu` or `:gpu`.
 

--- a/docs/src/solve/gpu.md
+++ b/docs/src/solve/gpu.md
@@ -52,7 +52,7 @@ ExaModels' own API, import it qualified: `using ExaModels: ExaModels`.
 
 `:exa` — the only GPU-capable modeler — requires dynamics (and any path constraint) written
 one coordinate at a time, `∂(x₁)(t) == ...`, not `ẋ(t) == [...]`. See
-[Abstract syntax](@ref modelling-abstract-syntax) for the two forms side by side.
+[Abstract syntax (`@def`)](@ref modelling-abstract-syntax) for the two forms side by side.
 
 ```julia
 ocp = @def begin

--- a/docs/src/solve/initial-guess.md
+++ b/docs/src/solve/initial-guess.md
@@ -361,4 +361,4 @@ under `using OptimalControl` is an open question, not a decision this page makes
 - [Overview](@ref solve-overview) — the rest of what `solve` accepts.
 - [Solution object](@ref results-solution) — `state`, `costate`, `control`, `variable` on a
   returned solution.
-- [Abstract syntax](@ref modelling-abstract-syntax) — where the labels `@init` uses come from.
+- [Abstract syntax (`@def`)](@ref modelling-abstract-syntax) — where the labels `@init` uses come from.


### PR DESCRIPTION
## Phase E4 of the documentation campaign — part 1 (A + C + D)

The mechanical coherence pass. Line wrapping (F16) is split into part 2; this PR is the naming coherence plus the small technical corrections and the two missing explanations.

Plan: `.reports/campaign/E4-coherence.md`. Naming choices settled with the maintainer beforehand (recorded there).

### F13 — one name per page
Twelve pages whose **sidebar label, H1, and cross-link text disagreed** are unified — the name is now identical in `make.jl`, the H1, and every `@ref`:

| page | was | now |
| --- | --- | --- |
| `geometry/ad.md` | sidebar `ad` | `Lie derivative and Lie bracket` |
| `geometry/poisson.md` | sidebar `Poisson` | `Poisson bracket` |
| `geometry/lie-macro.md` | sidebar `@Lie` | `The @Lie macro` |
| `geometry/ad-backend.md` | H1 "Choosing an AD backend" | `AD backend` |
| `flows/multi-phase.md` | sidebar `Multi-phase` | `Multi-phase flows` |
| `flows/shooting.md` | H1 "Writing a shooting function" | `Shooting` |
| `flows/from-hamiltonians.md` | H1 "…and vector fields" | `From Hamiltonians` |
| `examples/gallery.md` | sidebar `Gallery` | `Example gallery` |
| `examples/double-integrator-time.md` | sidebar hyphen | en-dash, matching the H1 |
| `modelling/abstract-syntax.md` | H1 "Abstract syntax" | ``Abstract syntax (`@def`)`` |
| `getting-started/first-problem.md` | sidebar "First problem" | `Your first problem` |

Three more pages carried a longer name **only in cross-links** (the part that actually confuses a reader) — realigned: `Problems without a control` (13×) → `No control`, `Simulating a controlled system` (4×) → `Simulation`, `What you can get back from a flow` (4×) → `Accessors`.

`index.md`'s "Getting started" site-map row pointed at the guided tour, jumping over the two pages before it — now points at the installation page.

### F17 — `geometry/ad-backend.md`
`import CTBase: Differentiation` → qualified `using` (the *qualified `using`, never `import`* tenet), and a new "Restoring the default" section that captures `default_backend` and sets it back, so the page no longer leaves the global AD backend changed for every page built after it.

### F18 — `geometry/lie-macro.md`
The `eval(:(@Lie [$F1,$F2] autonomous=false))` trick — used only to make a macro-expansion error catchable in a `@repl` block — is replaced by an inert REPL transcript.

### F25 — `flows/shooting.md`
`solve(prob, …)` → `NonlinearSolve.solve(prob, …)`, matching the other ten shooting call sites.

### F24 — two missing explanations
Why the `-π/2 ≤ θ(t) ≤ π/2` box in `singular-control.md` is harmless for the indirect shooting that ignores it; and what `v(t) + 0.0 ≤ VMAX` triggers in the parser (a nonlinear **path** constraint with a dual, reachable by its label — not a plain state box bound), on `constrained-arcs.md` with a one-liner + link on `state-constraint.md`.

### F22 — `docs/reports/00-cahier-des-charges.md`
The §12 acceptance criterion for `autonomous=` now excludes the supported `is_autonomous=` spelling and CTModels' real `time_dependence!(…; autonomous=…)` signature.

### F23 — `examples/singular-control.md`
The `us_bracket == sin(θ)²` equality is now shown **right where the closed form is introduced**, verified on the singular surface `{H₁ = 0, H₀₁ = 0}` (where it holds for any state), instead of only seventy lines later along the computed extremal — that check is kept, shorter, as a complementary confirmation.

## Verification

Full `julia --project=. docs/make.jl`: exit 0, **0** unresolved `@ref`, **0** failed `@example`. The 4 `@extref` warnings are the unchanged Phase-D upstream backlog under `warnonly`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)