### PR TITLE
docs: wrap over-long code lines (Phase E4 part 2, F16)

### DIFF
--- a/docs/src/examples/control-and-variable.md
+++ b/docs/src/examples/control-and-variable.md
@@ -67,7 +67,9 @@ f_growth = Flow(ocp_growth, u_growth)
 
 function shoot_growth!(s, ξ)
     p0, λ = ξ[1], ξ[2]
-    _, p_tf, pλ_tf = f_growth(t0, x0, p0, tf; variable=λ, variable_costate=true)
+    _, p_tf, pλ_tf = f_growth(
+        t0, x0, p0, tf; variable=λ, variable_costate=true
+    )
     s[1] = p_tf
     s[2] = pλ_tf
     return nothing
@@ -89,7 +91,10 @@ p0_sol_growth, λ_sol = shoot_sol_growth.u
 
 ```@example main
 indirect_growth = f_growth((t0, tf), x0, p0_sol_growth; variable=λ_sol)
-plot!(plt_growth, indirect_growth, :state, :control; label="Indirect", linestyle=:dash)
+plot!(
+    plt_growth, indirect_growth, :state, :control;
+    label="Indirect", linestyle=:dash,
+)
 ```
 
 ## Harmonic oscillator, with control
@@ -146,7 +151,9 @@ f_harmonic = Flow(ocp_harmonic, u_harmonic)
 
 function shoot_harmonic!(s, ξ)
     p0, ω = ξ[1:2], ξ[3]
-    x_tf, p_tf, pω_tf = f_harmonic(t0h, [q0, v0], p0, tfh; variable=ω, variable_costate=true)
+    x_tf, p_tf, pω_tf = f_harmonic(
+        t0h, [q0, v0], p0, tfh; variable=ω, variable_costate=true
+    )
     s[1] = x_tf[1]
     s[2] = p_tf[2]
     s[3] = pω_tf + 2ω
@@ -161,16 +168,23 @@ p0_guess_h = costate(harmonic_sol)(t0h)
 ω_guess = variable(harmonic_sol)
 
 prob_harmonic = NonlinearProblem(nle_harmonic!, [p0_guess_h..., ω_guess])
-shoot_sol_harmonic = NonlinearSolve.solve(prob_harmonic; show_trace=Val(false))
+shoot_sol_harmonic = NonlinearSolve.solve(
+    prob_harmonic; show_trace=Val(false)
+)
 p0_sol_harmonic, ω_sol = shoot_sol_harmonic.u[1:2], shoot_sol_harmonic.u[3]
 ```
 
 ### Comparison
 
 ```@example main
-indirect_harmonic = f_harmonic((t0h, tfh), [q0, v0], p0_sol_harmonic; variable=ω_sol)
+indirect_harmonic = f_harmonic(
+    (t0h, tfh), [q0, v0], p0_sol_harmonic; variable=ω_sol
+)
 plt_harmonic = plot(harmonic_sol, :state, :control; label="Direct")
-plot!(plt_harmonic, indirect_harmonic, :state, :control; label="Indirect", linestyle=:dash)
+plot!(
+    plt_harmonic, indirect_harmonic, :state, :control;
+    label="Indirect", linestyle=:dash,
+)
 ```
 
 ## See also

--- a/docs/src/examples/control-free.md
+++ b/docs/src/examples/control-free.md
@@ -57,7 +57,10 @@ println("estimated λ = ", variable(growth_sol))
 ```@example main
 t_grid = time_grid(growth_sol)
 plt_growth = plot(growth_sol, :state; label="Direct")
-plot!(plt_growth, t_grid, data.(t_grid); line=:dot, label="Data", color=:black)
+plot!(
+    plt_growth, t_grid, data.(t_grid);
+    line=:dot, label="Data", color=:black,
+)
 ```
 
 `model(growth_sol)` gives back the underlying problem the solution was computed from — the same
@@ -82,7 +85,9 @@ The costate $p$ and the variable's own costate $p_\lambda$ must both vanish at $
 ```@example main
 function shoot_growth!(s, ξ)
     p0, λ = ξ[1], ξ[2]
-    _, p_tf, pλ_tf = f_growth(t0, x0, p0, tf; variable=λ, variable_costate=true)
+    _, p_tf, pλ_tf = f_growth(
+        t0, x0, p0, tf; variable=λ, variable_costate=true
+    )
     s[1] = p_tf
     s[2] = pλ_tf
     return nothing
@@ -104,7 +109,10 @@ p0_sol_growth, λ_sol = shoot_sol_growth.u
 
 ```@example main
 indirect_growth = f_growth((t0, tf), x0, p0_sol_growth; variable=λ_sol)
-plot!(plt_growth, indirect_growth, :state; label="Indirect", linestyle=:dash)
+plot!(
+    plt_growth, indirect_growth, :state;
+    label="Indirect", linestyle=:dash,
+)
 ```
 
 The direct and indirect estimates of $\lambda$ agree, and both curves fit the noisy data
@@ -144,7 +152,10 @@ end
 
 ```@example main
 harmonic_sol = solve(ocp_harmonic; grid_size=20, display=false)
-println("estimated ω = ", variable(harmonic_sol), "  (expected π/2 ≈ ", π / 2, ")")
+println(
+    "estimated ω = ", variable(harmonic_sol),
+    "  (expected π/2 ≈ ", π / 2, ")",
+)
 ```
 
 ```@example main
@@ -158,7 +169,9 @@ f_harmonic = Flow(ocp_harmonic)
 
 function shoot_harmonic!(s, ξ)
     p0, ω = ξ[1:2], ξ[3]
-    x_tf, p_tf, pω_tf = f_harmonic(t0h, [q0, v0], p0, tfh; variable=ω, variable_costate=true)
+    x_tf, p_tf, pω_tf = f_harmonic(
+        t0h, [q0, v0], p0, tfh; variable=ω, variable_costate=true
+    )
     s[1] = x_tf[1]           # q(tf) = 0
     s[2] = p_tf[2]           # free final velocity
     s[3] = pω_tf + 2ω        # Mayer-cost transversality
@@ -173,7 +186,9 @@ p0_guess_h = costate(harmonic_sol)(t0h)
 ω_guess = variable(harmonic_sol)
 
 prob_harmonic = NonlinearProblem(nle_harmonic!, [p0_guess_h..., ω_guess])
-shoot_sol_harmonic = NonlinearSolve.solve(prob_harmonic; show_trace=Val(false))
+shoot_sol_harmonic = NonlinearSolve.solve(
+    prob_harmonic; show_trace=Val(false)
+)
 p0_sol_harmonic, ω_sol = shoot_sol_harmonic.u[1:2], shoot_sol_harmonic.u[3]
 println("indirect ω = ", ω_sol)
 ```
@@ -181,9 +196,14 @@ println("indirect ω = ", ω_sol)
 ### Comparison
 
 ```@example main
-indirect_harmonic = f_harmonic((t0h, tfh), [q0, v0], p0_sol_harmonic; variable=ω_sol)
+indirect_harmonic = f_harmonic(
+    (t0h, tfh), [q0, v0], p0_sol_harmonic; variable=ω_sol
+)
 plt_harmonic = plot(harmonic_sol, :state; label="Direct")
-plot!(plt_harmonic, indirect_harmonic, :state; label="Indirect", linestyle=:dash)
+plot!(
+    plt_harmonic, indirect_harmonic, :state;
+    label="Indirect", linestyle=:dash,
+)
 ```
 
 ## See also

--- a/docs/src/examples/double-integrator-time.md
+++ b/docs/src/examples/double-integrator-time.md
@@ -96,7 +96,8 @@ tf_guess = variable(direct_sol)
 
 prob = NonlinearProblem(nle!, ξ_guess)
 shooting_sol = NonlinearSolve.solve(prob; show_trace=Val(false))
-p0_sol, t1_sol, tf_sol = shooting_sol.u[1:2], shooting_sol.u[3], shooting_sol.u[4]
+p0_sol, t1_sol, tf_sol =
+    shooting_sol.u[1:2], shooting_sol.u[3], shooting_sol.u[4]
 ```
 
 ```@example main

--- a/docs/src/examples/singular-control.md
+++ b/docs/src/examples/singular-control.md
@@ -145,7 +145,8 @@ tf_guess = variable(direct_sol)
 
 prob = NonlinearProblem(nle!, ξ_guess)
 shooting_sol = NonlinearSolve.solve(prob; show_trace=Val(false))
-p0_sol, θ0_sol, tf_sol = shooting_sol.u[1:3], shooting_sol.u[4], shooting_sol.u[5]
+p0_sol, θ0_sol, tf_sol =
+    shooting_sol.u[1:3], shooting_sol.u[4], shooting_sol.u[5]
 ```
 
 ```@example main
@@ -158,7 +159,10 @@ s
 
 ```@example main
 indirect_sol = f((t0, tf_sol), [0, 0, θ0_sol], p0_sol; variable=tf_sol)
-plot!(plt, indirect_sol, :state, :control; label="Indirect", linestyle=:dash)
+plot!(
+    plt, indirect_sol, :state, :control;
+    label="Indirect", linestyle=:dash,
+)
 ```
 
 The indirect and direct solutions match closely, confirming the singular-control computation
@@ -170,7 +174,8 @@ The same equality, now along the computed extremal rather than a hand-picked sur
 ```@example main
 xs = state(indirect_sol)
 ps = costate(indirect_sol)
-[us_bracket(xs(t), ps(t)) - u_indirect(xs(t)) for t in range(t0, tf_sol, 5)]
+[us_bracket(xs(t), ps(t)) - u_indirect(xs(t))
+ for t in range(t0, tf_sol, 5)]
 ```
 
 ## See also

--- a/docs/src/examples/state-constraint.md
+++ b/docs/src/examples/state-constraint.md
@@ -109,7 +109,8 @@ t2_guess = t_grid[last(active)]
 
 prob = NonlinearProblem(nle!, ξ_guess)
 shooting_sol = NonlinearSolve.solve(prob; show_trace=Val(false))
-p0_sol, t1_sol, t2_sol = shooting_sol.u[1:2], shooting_sol.u[3], shooting_sol.u[4]
+p0_sol, t1_sol, t2_sol =
+    shooting_sol.u[1:2], shooting_sol.u[3], shooting_sol.u[4]
 ```
 
 ```@example main
@@ -123,7 +124,10 @@ s
 ```@example main
 φ = f_interior * (t1_sol, f_boundary) * (t2_sol, f_interior)
 indirect_sol = φ((t0, tf), x0, p0_sol)
-plot!(plt, indirect_sol, :state, :control; label="Indirect", linestyle=:dash)
+plot!(
+    plt, indirect_sol, :state, :control;
+    label="Indirect", linestyle=:dash,
+)
 ```
 
 ## Second-order constraint: bounding the position
@@ -201,11 +205,15 @@ p_of_t_touch = costate(sol_touch)
 p0_guess_t = p_of_t_touch(t0b)
 t1_guess_t = t_grid_t[argmin(abs.(g_touch.(state(sol_touch).(t_grid_t))))]
 ε = 0.05 * (tfb - t0b)
-Δpq_guess = p_of_t_touch(t1_guess_t + ε)[1] - p_of_t_touch(t1_guess_t - ε)[1]
+Δpq_guess =
+    p_of_t_touch(t1_guess_t + ε)[1] - p_of_t_touch(t1_guess_t - ε)[1]
 
-prob_touch = NonlinearProblem(nle_touch!, [p0_guess_t..., t1_guess_t, Δpq_guess])
+prob_touch = NonlinearProblem(
+    nle_touch!, [p0_guess_t..., t1_guess_t, Δpq_guess]
+)
 shoot_sol_touch = NonlinearSolve.solve(prob_touch; show_trace=Val(false))
-p0_touch, t1_touch, Δpq_touch = shoot_sol_touch.u[1:2], shoot_sol_touch.u[3], shoot_sol_touch.u[4]
+p0_touch, t1_touch, Δpq_touch =
+    shoot_sol_touch.u[1:2], shoot_sol_touch.u[3], shoot_sol_touch.u[4]
 ```
 
 ```@example main
@@ -227,7 +235,10 @@ sol_arc = solve(ocp_arc; grid_size=100, display=false)
 fs_arc = Flow(ocp_arc, (x, p) -> p[2])
 g_arc(x) = a_arc - x[1]
 
-fc_bd = Flow(ocp_arc, (x, p) -> 0.0; constraint=(x, u) -> g_arc(x), multiplier=(x, p) -> 0.0)
+fc_bd = Flow(
+    ocp_arc, (x, p) -> 0.0;
+    constraint=(x, u) -> g_arc(x), multiplier=(x, p) -> 0.0,
+)
 ```
 
 ```@example main
@@ -281,7 +292,8 @@ s
 ```
 
 ```@example main
-f_arc = fs_arc * (t1_arc, [Δpq1, 0.0], fc_bd) * (t2_arc, [Δpq2, 0.0], fs_arc)
+f_arc =
+    fs_arc * (t1_arc, [Δpq1, 0.0], fc_bd) * (t2_arc, [Δpq2, 0.0], fs_arc)
 indirect_arc = f_arc((t0b, tfb), x0_bd, p0_arc)
 plot!(plt2, indirect_arc, :state, :control; label="Indirect (a = 0.1)")
 ```

--- a/docs/src/flows/constrained-arcs.md
+++ b/docs/src/flows/constrained-arcs.md
@@ -29,7 +29,7 @@ t0 = 0.0
 tf = 1.0
 x0 = [-1.0, 0.0]
 xf = [0.0, 0.0]
-VMAX = 1.0        # the unconstrained transfer peaks at v = 1.5, so this bound bites
+VMAX = 1.0        # unconstrained transfer peaks at v = 1.5, so this bites
 
 ocp = @def begin
     t ∈ [t0, tf], time
@@ -54,7 +54,7 @@ its label. Adding `+ 0.0` makes it a nonlinear **path** constraint — it now ha
 ```@example main
 g(x) = VMAX - x[2]      # ≥ 0 away from the boundary, 0 on it
 μ(x, p) = p[1]           # feedback multiplier on the boundary arc: μ = p_q
-law(x, p) = 0.0           # the boundary control: u = 0 keeps v̇ = 0, holding v at VMAX
+law(x, p) = 0.0   # boundary control: u = 0 ⟹ v̇ = 0 ⟹ v = VMAX
 
 f_boundary = Flow(ocp, law; constraint=(x, u) -> g(x), multiplier=μ)
 
@@ -119,11 +119,11 @@ Pass matched tuples of functions (or labels) and multipliers, one per active con
 boundary arc, in place of the single values above:
 
 ```@example main
-g_q(x) = 10.0 - x[1]                       # a second bound, q ≤ 10 — slack on this arc
+g_q(x) = 10.0 - x[1]      # a second bound, q ≤ 10 — slack on this arc
 f_two = Flow(ocp, law;
              constraint = ((x, u) -> g(x), (x, u) -> g_q(x)),
              multiplier = (μ, (x, p) -> 0.0))
-f_two(t1, [-0.5, VMAX], p1, t2)[1] ≈ xb    # same arc: the extra constraint contributes nothing
+f_two(t1, [-0.5, VMAX], p1, t2)[1] ≈ xb   # extra bound is slack
 ```
 
 ## Assembling the arcs
@@ -135,8 +135,8 @@ constraint order requires one (none here: a first-order constraint keeps the cos
 continuous).
 
 ```@example main
-f_interior = Flow(ocp, (x, p) -> p[2])                  # u = p_v away from the boundary
-φ = f_interior * (t1, f_boundary) * (t2, f_interior)    # unconstrained · boundary · unconstrained
+f_interior = Flow(ocp, (x, p) -> p[2])   # u = p_v away from the boundary
+φ = f_interior * (t1, f_boundary) * (t2, f_interior)   # 3 arcs
 n_phases(φ)
 ```
 

--- a/docs/src/flows/from-ocp.md
+++ b/docs/src/flows/from-ocp.md
@@ -157,7 +157,9 @@ f_aug = Flow(ocp_aug, (x, p, ω) -> p[2])
 ω_val = π / 2
 p0_val = [1.0, 0.5]
 
-xf_aug, pf_aug, pω = f_aug(t0d, [q0, v0], p0_val, tfd; variable=ω_val, variable_costate=true)
+xf_aug, pf_aug, pω = f_aug(
+    t0d, [q0, v0], p0_val, tfd; variable=ω_val, variable_costate=true
+)
 pω
 ```
 
@@ -198,7 +200,7 @@ xf_total ≈ xf_partial
 ```
 
 ```@example main
-# :total reproduces the stationary law's trajectory exactly — the perturbation cancels
+# :total reproduces the stationary law's trajectory exactly
 xf_stationary, _ = Flow(ocp, (x, p) -> p[2])(t0, x0, p0, tf)
 xf_total ≈ xf_stationary
 ```

--- a/docs/src/flows/multi-phase.md
+++ b/docs/src/flows/multi-phase.md
@@ -27,7 +27,7 @@ typeof(f)
 ```
 
 ```@example main
-f(0.0, 0.0, 2.0)   # one unit of f1's zero slope, then one unit of f2's slope-1
+f(0.0, 0.0, 2.0)   # one unit of f1's flat, then one of f2's slope-1
 ```
 
 ## Jumps
@@ -60,8 +60,8 @@ A jump argument can be a function (as above), `nothing` for the identity (no jum
 — accepted in addition to the two — a plain `Vector` added to the state/costate directly:
 
 ```@example main
-h_identity = h1 * (1.0, nothing, nothing, h2)   # nothing, nothing ≡ no jump
-h_vec = h1 * (1.0, [0.0, 0.0], h2)               # a bare vector jump also works
+h_identity = h1 * (1.0, nothing, nothing, h2)   # nothing ≡ no jump
+h_vec = h1 * (1.0, [0.0, 0.0], h2)   # a bare vector jump works too
 nothing # hide
 ```
 

--- a/docs/src/flows/overview.md
+++ b/docs/src/flows/overview.md
@@ -144,7 +144,7 @@ constructing** a flow, not on the call:
 
 ```julia
 f = Flow(ocp, law; method=:gpu)   # correct — a constructor keyword
-f(t0, x0, p0, tf; method=:gpu)    # wrong — MethodError, no such call-time keyword
+f(t0, x0, p0, tf; method=:gpu)    # wrong — no such call-time keyword
 ```
 
 ## Where to go

--- a/docs/src/flows/shooting.md
+++ b/docs/src/flows/shooting.md
@@ -84,7 +84,9 @@ sqrt(sum(abs2, s))
 ```@example main
 ξ_guess = [1.0, 1.0, 1.0, 2.0] .* 1.1
 prob = NonlinearProblem((s, ξ, _) -> shoot!(s, ξ), ξ_guess)
-sol = NonlinearSolve.solve(prob, SimpleNewtonRaphson(); abstol=1e-10, reltol=1e-10)
+sol = NonlinearSolve.solve(
+    prob, SimpleNewtonRaphson(); abstol=1e-10, reltol=1e-10
+)
 sol.u, sol.retcode
 ```
 
@@ -122,7 +124,9 @@ condition — no separate machinery needed beyond adding it as a residual. For a
 directly if the transversality condition is stated in terms of $p_v(t_f)$ instead:
 
 ```@example main
-xf_v, pf_v, pvf = f_max(t0, x0, [1.0, 1.0], 1.0; variable=2.0, variable_costate=true)
+xf_v, pf_v, pvf = f_max(
+    t0, x0, [1.0, 1.0], 1.0; variable=2.0, variable_costate=true
+)
 pvf
 ```
 
@@ -157,7 +161,7 @@ p0_sol, t1_sol, tf_sol = sol.u[1:2], sol.u[3], sol.u[4]
 f_bb = f_max * (t1_sol, f_min)
 zf = f_bb(t0, x0, p0_sol, tf_sol; variable=tf_sol)
 
-zf[1:2]     # the final state ≈ [0, 0] — the indirect solution hits the target
+zf[1:2]     # final state ≈ [0, 0] — the indirect solution hits the target
 ```
 
 The two methods agree on the optimum. The cost here is the final time, so comparing objectives

--- a/docs/src/geometry/ad.md
+++ b/docs/src/geometry/ad.md
@@ -95,7 +95,7 @@ dg(3.0, [1.0, 2.0])   # ∂g/∂t = 2t = 6
 ```
 
 ```@example main
-dXV = ∂ₜ(XV)   # XV::VectorField, defined above — still comes back NonAutonomous
+dXV = ∂ₜ(XV)   # XV::VectorField from above — still NonAutonomous
 typeof(dXV)
 ```
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -21,8 +21,8 @@ Let us model, solve and plot a simple optimal control problem.
 
 ```@example main
 using OptimalControl
-using NLPModelsIpopt  # activates the Ipopt solver extension (required for solve)
-using Plots           # activates the plotting extension (required for plot)
+using NLPModelsIpopt  # Ipopt solver extension (needed for solve)
+using Plots           # plotting extension (needed for plot)
 
 ocp = @def begin
     t ∈ [0, 1], time
@@ -110,9 +110,9 @@ function _downloads_toml(DIR)
     link_manifest = joinpath("assets", DIR, "Manifest.toml")
     link_project = joinpath("assets", DIR, "Project.toml")
     return Markdown.parse("""
-    You can download the exact environment used to build this documentation:
+    Download the exact environment used to build these docs:
     - 📦 [Project.toml]($link_project) - Package dependencies
-    - 📋 [Manifest.toml]($link_manifest) - Complete dependency tree with versions
+    - 📋 [Manifest.toml]($link_manifest) - Full dependency tree
     """)
 end
 ```

--- a/docs/src/migration.md
+++ b/docs/src/migration.md
@@ -232,7 +232,7 @@ ERROR: PreconditionError: `f(t0, x0, p0, tf, lambda)` is deprecated
 Reason  this spelling was removed in v2.1.0-beta
 Hint    use f(t0, x0, p0, tf; variable=lambda)
 
-julia> f(t0, x0, tf, λ)   # 4-positional, on a plain state flow (AbstractStateFlow)
+julia> f(t0, x0, tf, λ)   # 4-positional, on a plain state flow
 ERROR: PreconditionError: `f(t0, x0, tf, lambda)` is deprecated
 Reason  this spelling was removed in v2.1.0-beta
 Hint    use f(t0, x0, tf; variable=lambda)

--- a/docs/src/modelling/abstract-syntax.md
+++ b/docs/src/modelling/abstract-syntax.md
@@ -25,8 +25,8 @@ While the syntax will be transparent to those users familiar with Julia expressi
 
 ```@setup abs
 using OptimalControl
-data(t) = 2exp(0.5t)   # observed-data stub for the parameter-estimation example
-c(t) = 1.0             # coefficient stub for the damped-integrator examples
+data(t) = 2exp(0.5t)   # observed-data stub (parameter estimation)
+c(t) = 1.0             # coefficient stub (damped integrator)
 ```
 
 ## [Variable](@id modelling-abstract-syntax-variable)

--- a/docs/src/modelling/functional-api.md
+++ b/docs/src/modelling/functional-api.md
@@ -40,25 +40,25 @@ using OptimalControl
 
 pre = OptimalControl.PreModel()
 
-# ─── Optional: must come before time! when using indf/ind0 ───────────────────
+# ─── Optional: before time! when using indf/ind0 ───────────────
 variable!(pre, q)                         # q = variable dimension
-# ─────────────────────────────────────────────────────────────────────────────
+# ───────────────────────────────────────────────────────────────
 
 time!(pre; t0=..., tf=...)                # fixed times
-# or: time!(pre; t0=..., indf=i)          # free final time at variable index i
+# or: time!(pre; t0=..., indf=i)   # free final time at var index i
 
 state!(pre, n)                            # n = state dimension
 
-# ─── Optional: omit entirely for control-free problems ───────────────────────
+# ─── Optional: omit for control-free problems ──────────────────
 control!(pre, m)                          # m = control dimension
-# ─────────────────────────────────────────────────────────────────────────────
+# ───────────────────────────────────────────────────────────────
 
 # Dynamics — in-place, signature: dyn!(dx, t, x, u, v)
-#   dx : output vector (modified in place), length n — always a vector, even for n=1
+#   dx : output vector (modified in place), length n (vector even for n=1)
 #   t  : current time  (scalar)
 #   x  : state         (scalar if n=1, vector of length n otherwise)
-#   u  : control       (scalar if m=1, vector of length m otherwise; `nothing` if control-free)
-#   v  : variable      (scalar if q=1, vector of length q otherwise; `nothing` if no variable)
+#   u  : control    (scalar if m=1 else vector; `nothing` if control-free)
+#   v  : variable   (scalar if q=1 else vector; `nothing` if none)
 function dyn!(dx, t, x, u, v)
     dx[1] = ...
     dx[2] = ...
@@ -76,11 +76,11 @@ objective!(pre, :min; lagrange=lag)                   # Lagrange cost
 # or: objective!(pre, :min; mayer=may)                # Mayer cost
 # or: objective!(pre, :min; mayer=may, lagrange=lag)  # Bolza cost
 
-# ─── Optional: one call per constraint ───────────────────────────────────────
+# ─── Optional: one call per constraint ─────────────────────────
 # Two families of constraints:
 #
 # (a) Box constraints on components — :state, :control, :variable
-#     rg selects the component range i:j, with lb ≤ x[rg] ≤ ub (resp. u, v).
+#     rg selects the range i:j, with lb ≤ x[rg] ≤ ub (resp. u, v).
 constraint!(pre, :state;    rg=i:j, lb=..., ub=..., label=:name)
 constraint!(pre, :control;  rg=i:j, lb=..., ub=..., label=:name)
 constraint!(pre, :variable; rg=i:j, lb=..., ub=..., label=:name)
@@ -88,10 +88,10 @@ constraint!(pre, :variable; rg=i:j, lb=..., ub=..., label=:name)
 # (b) Non-linear constraints defined by a function — :boundary, :path
 #     The constraint reads:  lb ≤ f(...) ≤ ub  (use lb=ub for equality).
 #
-#     Boundary — in-place, signature: b!(val, x0, xf, v)   (same shape as Mayer)
-#         val : output vector (modified in place), length = length(lb) = length(ub)
-#     Path — in-place, signature: p!(val, t, x, u, v)      (same shape as dynamics)
-#         val : output vector (modified in place), length = length(lb) = length(ub)
+#     Boundary — in-place: b!(val, x0, xf, v)   (same shape as Mayer)
+#         val : vector (in place), length = length(lb) = length(ub)
+#     Path — in-place: p!(val, t, x, u, v)      (same shape as dynamics)
+#         val : vector (in place), length = length(lb) = length(ub)
 function b!(val, x0, xf, v)
     val[1] = ...
 end
@@ -101,7 +101,7 @@ function p!(val, t, x, u, v)
     val[1] = ...
 end
 constraint!(pre, :path; f=p!, lb=..., ub=..., label=:name)
-# ─────────────────────────────────────────────────────────────────────────────
+# ───────────────────────────────────────────────────────────────
 
 # autonomous=true  ⟺  time t does NOT appear explicitly in the dynamics,
 #                     the Lagrange integrand, nor in any :path constraint.
@@ -207,13 +207,24 @@ Both formulations produce identical solutions. We solve both and plot them toget
 sol_macro = solve(ocp_macro; display=false)
 sol_func = solve(ocp_func; display=false)
 
-println("Macro: objective = ", objective(sol_macro), ", iterations = ", iterations(sol_macro))
-println("Functional API: objective = ", objective(sol_func), ", iterations = ", iterations(sol_func))
+println(
+    "Macro: objective = ", objective(sol_macro),
+    ", iterations = ", iterations(sol_macro),
+)
+println(
+    "Functional API: objective = ", objective(sol_func),
+    ", iterations = ", iterations(sol_func),
+)
 ```
 
 ```@example ex-energy
-plt = plot(sol_macro, :state, :control; label="Macro", color=1, size=(800, 600))
-plot!(plt, sol_func, :state, :control; label="Functional API", color=2, linestyle=:dash)
+plt = plot(
+    sol_macro, :state, :control; label="Macro", color=1, size=(800, 600)
+)
+plot!(
+    plt, sol_func, :state, :control;
+    label="Functional API", color=2, linestyle=:dash,
+)
 ```
 
 The two models are functionally equivalent. The key difference is visible via [`definition`](@ref): the macro records the full DSL expression, whereas the functional API stores an empty definition.
@@ -243,7 +254,7 @@ typeof(u_macro(t0)), typeof(u_func(t0))
 The **in-place output buffer is the one exception**: `dx` (dynamics), `val` (boundary/path constraints) is always a vector of its declared length, written by index, even when that length is 1 — a scalar cannot be mutated in place:
 
 ```julia
-f!(r, t, x, u, v) = (r[1] = -x + u; nothing)  # r is always a vector; x, u here are scalars
+f!(r, t, x, u, v) = (r[1] = -x + u; nothing)  # r vector; x,u scalars
 ```
 
 This is the one place on the site where this is spelled out; every other page just follows it.

--- a/docs/src/modelling/inspect.md
+++ b/docs/src/modelling/inspect.md
@@ -97,7 +97,7 @@ has_free_final_time(ocp)
 ### Autonomy
 
 ```@example main
-is_autonomous(ocp)  # false if the dynamics or the Lagrange cost depend on time
+is_autonomous(ocp)  # false if dynamics or Lagrange cost depend on t
 ```
 
 See [Time dependence](@ref modelling-inspect-time-dependence) below.
@@ -246,7 +246,7 @@ s = 0.5; q = [1.0, 2.0]; u = 3.0
 ```
 
 ```@example main
-(type, f, lb, ub) = constraint(ocp, :cons_mixed)   # a path (mixed state–control) constraint
+(type, f, lb, ub) = constraint(ocp, :cons_mixed)  # a mixed path constraint
 (type, f(s, q, u, v))
 ```
 
@@ -279,7 +279,7 @@ nothing # hide
 ```
 
 ```@example main
-has_abstract_definition(ocp)  # false for a functional-API model (EmptyDefinition)
+has_abstract_definition(ocp)  # false for a functional-API model
 ```
 
 ## [Time dependence](@id modelling-inspect-time-dependence)

--- a/docs/src/modelling/without-control.md
+++ b/docs/src/modelling/without-control.md
@@ -75,7 +75,10 @@ nothing # hide
 ```@example main
 plt = plot(sol, :state; size=(800, 400), label="Direct")
 tg = time_grid(sol)
-plot!(plt, tg, data.(tg); subplot=1, line=:dot, lw=2, label="Data", color=:black)
+plot!(
+    plt, tg, data.(tg);
+    subplot=1, line=:dot, lw=2, label="Data", color=:black,
+)
 ```
 
 The estimate is close to $\lambda \approx 0.5$. The indirect (PMP shooting) solution of the

--- a/docs/src/results/plot.md
+++ b/docs/src/results/plot.md
@@ -56,7 +56,10 @@ With every group shown, the layout is a grid: state trajectories on the left, co
 right, control along the bottom.
 
 ```@example main
-plot(sol, :state, :costate, :control; size=(700, 450), legend=:bottomright, grid=false, linewidth=2)
+plot(
+    sol, :state, :costate, :control;
+    size=(700, 450), legend=:bottomright, grid=false, linewidth=2,
+)
 ```
 
 `state_style`, `costate_style`, and `control_style` set series attributes per group (any
@@ -120,7 +123,7 @@ plot(sol; control=:norm, layout=:group, size=(800, 300))
 ```
 
 ```@example main
-plot(sol; control=:components, layout=:group, size=(800, 300))  # the default
+plot(sol; control=:components, layout=:group, size=(800, 300))  # default
 ```
 
 ```@example main
@@ -158,14 +161,20 @@ solutions = [solve(lqr(tf); display=false) for tf in tfs]
 
 plt = plot()
 for (tf, sol) in zip(tfs, solutions)
-    plot!(plt, sol, :state, :control; time=:normalize, label="tf = $tf", xlabel="s")
+    plot!(
+        plt, sol, :state, :control;
+        time=:normalize, label="tf = $tf", xlabel="s",
+    )
 end
 
 using Plots.PlotMeasures
 px1 = plot(plt[1]; legend=false)  # x₁
 px2 = plot(plt[2]; legend=true)   # x₂
 pu = plot(plt[3]; legend=false)   # u
-plot(px1, px2, pu; layout=(1, 3), size=(800, 300), leftmargin=5mm, bottommargin=5mm)
+plot(
+    px1, px2, pu;
+    layout=(1, 3), size=(800, 300), leftmargin=5mm, bottommargin=5mm,
+)
 ```
 
 ## Constraints
@@ -260,7 +269,7 @@ using OrdinaryDiffEqTsit5
 
 p = costate(sol)
 p0 = p(t0)
-f = Flow(ocp, (x, p) -> p[2])  # flow from an ocp and a feedback control law
+f = Flow(ocp, (x, p) -> p[2])  # flow from an ocp + a feedback law
 
 sol_flow = f((t0, tf), x0, p0)
 plot(sol_flow)

--- a/docs/src/results/solution.md
+++ b/docs/src/results/solution.md
@@ -225,7 +225,9 @@ variable_constraints_lb_dual(sol), variable_constraints_ub_dual(sol)
 with matching dimension accessors:
 
 ```@example main
-dim_dual_state_constraints_box(sol), dim_dual_control_constraints_box(sol), dim_dual_variable_constraints_box(sol)
+dim_dual_state_constraints_box(sol),
+dim_dual_control_constraints_box(sol),
+dim_dual_variable_constraints_box(sol)
 ```
 
 And the nonlinear (path/boundary) duals as a whole, plus their counts:

--- a/docs/src/solve/choosing-a-method.md
+++ b/docs/src/solve/choosing-a-method.md
@@ -56,9 +56,9 @@ Completion walks `methods()` from top to bottom and returns the first entry cont
 token you gave:
 
 ```julia
-solve(ocp, :madnlp)   # → (:collocation, :adnlp, :madnlp, :cpu)  — first entry with :madnlp
-solve(ocp, :exa)      # → (:collocation, :exa,   :ipopt,  :cpu)  — first entry with :exa
-solve(ocp, :gpu)      # → (:collocation, :exa,   :madnlp, :gpu)  — first GPU entry
+solve(ocp, :madnlp)   # → (:collocation, :adnlp, :madnlp, :cpu)
+solve(ocp, :exa)      # → (:collocation, :exa,   :ipopt,  :cpu)
+solve(ocp, :gpu)      # → (:collocation, :exa,   :madnlp, :gpu)
 ```
 
 This first-match-top-to-bottom rule is also why the plain `solve(ocp)` default is
@@ -66,7 +66,7 @@ This first-match-top-to-bottom rule is also why the plain `solve(ocp)` default i
 equivalent:
 
 ```julia
-solve(ocp)                                      # empty description → methods()[1]
+solve(ocp)                       # empty description → methods()[1]
 solve(ocp, :collocation)
 solve(ocp, :adnlp)
 solve(ocp, :ipopt)

--- a/docs/src/solve/explicit-mode.md
+++ b/docs/src/solve/explicit-mode.md
@@ -57,11 +57,15 @@ Give one component, and the other two are completed the same way descriptive mod
 partial token list — first match, top to bottom in [`methods`](@ref)`()`:
 
 ```@example explicit
-methods()[1]  # (:collocation, :adnlp, :ipopt, :cpu) — what a bare solve(ocp) completes to
+methods()[1]  # what a bare solve(ocp) completes to
 ```
 
 ```@example explicit
-result = solve(ocp; solver=OptimalControl.Ipopt(max_iter=2000, print_level=0), display=true)
+result = solve(
+    ocp;
+    solver=OptimalControl.Ipopt(max_iter=2000, print_level=0),
+    display=true,
+)
 nothing # hide
 ```
 
@@ -86,7 +90,9 @@ afterward, unlike descriptive mode:
 ```@example explicit
 disc = OptimalControl.Collocation(grid_size=150, scheme=:gauss_legendre_2)
 mod = OptimalControl.ADNLP(backend=:optimized, show_time=true)
-sol = OptimalControl.Ipopt(max_iter=1000, tol=1e-8, print_level=5, acceptable_tol=1e-6)
+sol = OptimalControl.Ipopt(
+    max_iter=1000, tol=1e-8, print_level=5, acceptable_tol=1e-6
+)
 nothing # hide
 ```
 
@@ -94,7 +100,9 @@ Undeclared options still need `bypass` (or its alias `force`), same reasoning as
 mode — but here it's passed straight into the constructor, not through `route_to`:
 
 ```@example explicit
-solver = OptimalControl.Ipopt(max_iter=500, print_level=0, mumps_print_level=bypass(1))
+solver = OptimalControl.Ipopt(
+    max_iter=500, print_level=0, mumps_print_level=bypass(1)
+)
 nothing # hide
 ```
 

--- a/docs/src/solve/gpu.md
+++ b/docs/src/solve/gpu.md
@@ -76,7 +76,9 @@ end
 The `:gpu` parameter token selects GPU-optimized defaults:
 
 ```julia
-sol = solve(ocp, :exa, :madnlp, :gpu; grid_size=100, print_level=MadNLP.ERROR)
+sol = solve(
+    ocp, :exa, :madnlp, :gpu; grid_size=100, print_level=MadNLP.ERROR
+)
 
 # or, letting completion fill in the rest — first match with :gpu:
 sol = solve(ocp, :gpu; grid_size=100, print_level=MadNLP.ERROR)

--- a/docs/src/solve/options.md
+++ b/docs/src/solve/options.md
@@ -127,7 +127,7 @@ s = OptimalControl.Ipopt(max_iter=200)
 println(has_option(s, :max_iter))      # true — Ipopt declares this option
 println(has_option(s, :not_an_option)) # false
 println(option_value(s, :max_iter))    # 200 — what will actually be used
-println(option_value(s, :tol))         # 1.0e-8 — the strategy's own default
+println(option_value(s, :tol))         # 1.0e-8 — strategy default
 
 opts = options(s)
 println(is_user(opts, :max_iter))      # true


### PR DESCRIPTION
## Phase E4 of the documentation campaign — part 2 (F16)

**Stacked on #917** (`docs/coherence-pass`) — retarget to `main` once that merges.

Pure line-wrapping, no behaviour change. Every Julia line over ~75 characters inside `@example` / `@repl` / `@setup` / ```` ```julia ```` blocks is brought within the Handbook's *Code cell line width* limit:

- multi-argument calls wrapped `f(\n    args…\n)`, one group per line with a trailing comma;
- tuple unpacks broken after `=`;
- over-long trailing comments trimmed;
- `modelling/functional-api.md`'s annotated reference card narrowed to ~73.

Recount before starting: **114** lines over 75 in fenced blocks, of which ~60 were wrappable Julia code — now **0**.

### Deliberately not touched
- **Five REPL output lines** — `ERROR:` / `Hint …` / `│ Context …` boxes on `flows/overview.md`, `getting-started/installation.md`, `results/save-load.md`, `migration.md` (×2). These are literal tool output, not calls; the Handbook rule is *"long calls wrap"*, and reflowing shown output would falsify it.
- **LaTeX math, BibTeX, `@raw html`** (the AI-assistant buttons on `with-ai.md` are ~450 chars of inline-styled `<a>`) — none in the Handbook's scope.
- **`getting-started/guided-tour.md`** — Literate-generated from `src-literate/tutorial.jl`; belongs to Phase E5.

## Verification

Full `julia --project=. docs/make.jl`: exit 0, **0** unresolved `@ref`, **0** failed `@example`. The 4 `@extref` warnings are the unchanged Phase-D upstream backlog under `warnonly`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)