### PR TITLE
docs: adopt CTParser 0.9.5-beta — #343/#344 fixed upstream

### DIFF
--- a/docs/src/assets/Manifest.toml
+++ b/docs/src/assets/Manifest.toml
@@ -225,9 +225,9 @@ version = "0.30.2-beta"
 
 [[deps.CTDirect]]
 deps = ["ADNLPModels", "CTBase", "CTModels", "CTParser", "CTSolvers", "DocStringExtensions", "ExaModels", "SolverCore", "SparseArrays", "SparseConnectivityTracer"]
-git-tree-sha1 = "f5b16f5b312265d2000cf1ce2a46ad219b1e4717"
+git-tree-sha1 = "f88e02b5c7102b24efa7e89c558c6d8fc67015e5"
 uuid = "790bbbee-bee9-49ee-8912-a9de031322d5"
-version = "1.1.5-beta"
+version = "1.1.6-beta"
 
 [[deps.CTFlows]]
 deps = ["ADTypes", "CTBase", "CTModels", "CTSolvers", "CommonSolve", "DocStringExtensions", "GPUArraysCore", "RecipesBase"]
@@ -274,9 +274,9 @@ version = "0.19.2-beta"
 
 [[deps.CTParser]]
 deps = ["CTBase", "DocStringExtensions", "MLStyle", "OrderedCollections", "Parameters", "Unicode"]
-git-tree-sha1 = "5b64179056b79c42ee4fd748e55e98e5a1e3f5e9"
+git-tree-sha1 = "3f745c73919729ca654d02e1091fce5583facacc"
 uuid = "32681960-a1b1-40db-9bff-a1ca817385d1"
-version = "0.9.4-beta"
+version = "0.9.5-beta"
 weakdeps = ["ExaModels", "LinearAlgebra"]
 
     [deps.CTParser.extensions]

--- a/docs/src/modelling/abstract-syntax.md
+++ b/docs/src/modelling/abstract-syntax.md
@@ -421,7 +421,7 @@ nothing # hide
     ```
 
 !!! warning
-    Constraint bounds must be *effective*, that is must not depend on a variable. For instance, the following is rejected (the message is currently not explicit — the cause is `x₂(0) == v` using the variable `v` as a bound):
+    A constraint *bound* must be constant — it may not depend on the variable, the state, the control or the time. The following is rejected, with a message naming the cause:
 
     ```@repl abs
     try # hide
@@ -432,7 +432,7 @@ nothing # hide
         u ∈ R, control
         -1 ≤ v ≤ 1
         x₁(0) == -1
-        x₂(0) == v # wrong: the bound is not effective (it depends on the variable)
+        x₂(0) == v # wrong: the bound v depends on the variable
         x(1) == [0, 0]
         ẋ(t) == [x₂(t), u(t)]
         ∫(0.5u(t)^2) → min
@@ -442,7 +442,7 @@ nothing # hide
     end # hide
     ```
 
-    Write instead a boundary constraint, which *may* involve the variable:
+    Write instead a boundary constraint, moving the term to the constrained side — that side *may* involve the variable:
 
     ```@example abs
     @def begin


### PR DESCRIPTION
## Follow-up to E1 — two CTParser rough edges, now fixed

E1 (#913, making `abstract-syntax.md` executable) filed two CTParser issues and softened the doc prose meanwhile. **CTParser 0.9.5-beta** — PRs [#345](https://github.com/control-toolbox/CTParser.jl/pull/345) / [#347](https://github.com/control-toolbox/CTParser.jl/pull/347), phases K/L of [#326](https://github.com/control-toolbox/CTParser.jl/pull/326) — fixes both, with no breaking changes (#343 only affects inputs that already errored; #344 is trace-only output).

### [CTParser#343](https://github.com/control-toolbox/CTParser.jl/issues/343) — constraint bound depending on the variable

Was rejected with a leaked internal gensym:
```
Line 7: x₂(0) == v
UndefVarError: `v##286` not defined in `Main`
```
Now a `CTBase.ParsingError` naming the cause and the fix, and the check is broader — a bound depending on the **variable, the state, the control, or the time** is caught, backend-agnostic:
```
Line 7: x₂(0) == v
the lower bound of a constraint must not depend on the variable; write a functional
constraint instead by moving the term to the constrained side (e.g. `x₂(0) - v == 0`
rather than `x₂(0) == v`)
```
The `!!! warning` on `abstract-syntax.md` no longer says *"the message is currently not explicit"* and now names all four kinds of dependency.

### [CTParser#344](https://github.com/control-toolbox/CTParser.jl/issues/344) — trace mode double-print

`@def name … end true` printed the parsed model **twice** (the `:exa` re-parse inside `def_fun` inherited the `log` flag). Now once. The `!!! hint` block renders a single copy — no prose change.

## Dependency

`[compat] CTParser = "0.9"` already admits `0.9.5-beta`, so **no `Project.toml` change**. `docs/src/assets/Manifest.toml` (the tracked reproducibility snapshot, regenerated by `make.jl`) records:
- `CTParser` `0.9.4-beta` → `0.9.5-beta`
- `CTDirect` `1.1.5-beta` → `1.1.6-beta` — pulled in by the resolver; a **docs-only** release (CTDirect#631, two inherited-docstring `@ref` fixes, no source or API change).

## Verification

Full `julia --project=. docs/make.jl`: exit 0, **0** unresolved `@ref`, **0** failed `@example`. `#343` renders the `ParsingError`; `#344` renders one trace block. The 4 `@extref` warnings are the unchanged Phase-D upstream backlog under `warnonly`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)