### PR TITLE
docs: VitePress code annotations + one mis-rendered list (Phase J)

### DIFF
--- a/docs/src/flows/overview.md
+++ b/docs/src/flows/overview.md
@@ -50,13 +50,13 @@ numerically.
 
 ## Three things this section does
 
-1. **Indirect solving** — [From an OCP](@ref flows-from-ocp),
-   [Constrained arcs](@ref flows-constrained-arcs), [Multi-phase flows](@ref flows-multi-phase),
-   [Shooting](@ref flows-shooting).
-2. **Simulation** — [Simulation](@ref flows-simulation): integrate under a
-   given control, no optimization involved.
-3. **Inspection** — [Accessors](@ref flows-accessors): the Hamiltonian,
-   its vector field, the pseudo-Hamiltonian, the control law you passed in.
+- **Indirect solving** — [From an OCP](@ref flows-from-ocp),
+  [Constrained arcs](@ref flows-constrained-arcs), [Multi-phase flows](@ref flows-multi-phase),
+  [Shooting](@ref flows-shooting).
+- **Simulation** — [Simulation](@ref flows-simulation): integrate under a
+  given control, no optimization involved.
+- **Inspection** — [Accessors](@ref flows-accessors): the Hamiltonian,
+  its vector field, the pseudo-Hamiltonian, the control law you passed in.
 
 [From Hamiltonians](@ref flows-from-hamiltonians) covers the lower-level
 constructors these three jobs are all built from.

--- a/docs/src/migration.md
+++ b/docs/src/migration.md
@@ -76,13 +76,10 @@ Three call conventions changed signature, not just spelling.
 **The flow call.** There is no positional slot for the variable any more:
 
 ```julia
-# before
-f(t0, x0, p0, tf, λ)
-f(t0, x0, p0, tf; augment=true)
-
-# after
-f(t0, x0, p0, tf; variable=λ)
-f(t0, x0, p0, tf; variable=λ, variable_costate=true)
+f(t0, x0, p0, tf, λ)                                  # [!code --]
+f(t0, x0, p0, tf; augment=true)                       # [!code --]
+f(t0, x0, p0, tf; variable=λ)                         # [!code ++]
+f(t0, x0, p0, tf; variable=λ, variable_costate=true)  # [!code ++]
 ```
 
 `variable=` is mandatory on a `NonFixed` problem — omitting it does not silently default, it
@@ -102,11 +99,8 @@ f(t0, x0, p0, tf)
 **Constrained flows.** Positional arguments became a keyword pair:
 
 ```julia
-# before
-fb = Flow(ocp, u, g, μ)                            # 3 positional
-
-# after
-fb = Flow(ocp, u; constraint=g, multiplier=μ)      # paired keywords
+fb = Flow(ocp, u, g, μ)                         # 3 positional     [!code --]
+fb = Flow(ocp, u; constraint=g, multiplier=μ)   # paired keywords  [!code ++]
 ```
 
 The two keywords are a pair: one without the other is an `IncorrectArgument`. `constraint=`
@@ -118,13 +112,10 @@ now also accepts a `Symbol` naming a `:path` constraint already declared in the 
 every sibling `Data` constructor:
 
 ```julia
-# before
-VectorField(f; autonomous=false, variable=true)
-@Lie [X, Y] autonomous=false
-
-# after
-VectorField(f; is_autonomous=false, is_variable=true)
-@Lie [X, Y] is_autonomous=false
+VectorField(f; autonomous=false, variable=true)        # [!code --]
+@Lie [X, Y] autonomous=false                            # [!code --]
+VectorField(f; is_autonomous=false, is_variable=true)   # [!code ++]
+@Lie [X, Y] is_autonomous=false                         # [!code ++]
 ```
 
 The old spelling on `@Lie` raises an `IncorrectArgument` at macro-expansion time — loud, not
@@ -157,8 +148,8 @@ the current package.
     closure **constructs without error** and only fails once the flow actually runs:
 
     ```julia
-    bad_law = OpenLoop(() -> 1.0)          # constructs fine — the trap
-    Flow(ControlledVectorField(fc), bad_law)(t0, x0, tf)   # MethodError here, not above
+    bad_law = OpenLoop(() -> 1.0)                          # constructs fine — the trap
+    Flow(ControlledVectorField(fc), bad_law)(t0, x0, tf)   # MethodError here, not above  [!code error]
     ```
 
     The `MethodError` points at the call site, far from the actual mistake at construction.
@@ -175,7 +166,7 @@ the current package.
     instead of erroring — `tf` silently becomes `p0` and `λ` silently becomes `tf`:
 
     ```julia
-    f(t0, x0, tf, λ)   # intended: state flow, tf and lambda as before
+    f(t0, x0, tf, λ)   # intended: state flow, tf and lambda as before  [!code warning]
     # actually runs as f(t0, x0, p0=tf, tf=λ)  — arguments shifted by one position
     ```
 


### PR DESCRIPTION
## What

Phase J: use the VitePress code-block features DocumenterVitepress exposes but the site never used (`grep -r '\[!code' docs/src` → 0). Plus the one source-level ordered list the [DocumenterVitepress#150](https://github.com/LuxDL/DocumenterVitepress.jl/issues/150) mis-numbering bug hits.

**J turned out small.** The only page with genuine *before/after* pairs is `migration.md`. Nothing else in the current docs has a before/after pair, a "one line that matters" long snippet, or two genuine alternatives side by side. Full classification in `.reports/campaign/J-code-presentation.md`.

## Changes

**`migration.md`**
- 3 `# before` / `# after` block pairs → one block each with `# [!code --]` / `# [!code ++]` (red/green diff gutter). Inline explanatory comments (`# 3 positional` / `# paired keywords`) kept — the `[!code …]` token is stripped from the rendered comment.
- the `OpenLoop` construction trap → `# [!code error]`
- the 4-positional silent-misread call → `# [!code warning]`
- both `[!code]`-in-admonition, verified to render (`has-error` / `has-warning` in the built HTML)

**`flows/overview.md`**
- "Three things this section does" ordered list → unordered. DocumenterVitepress mis-numbers any ordered list whose items carry block content (#150); these three are a set, not a sequence.

Not touched: the `api/*` ordered lists (same bug, but sourced from **CTBase/CTSolvers docstrings** — cross-repo); executed `@example` blocks (annotations don't work there); `abstract-syntax.md`'s `:( … )` grammar patterns (E1's deliberate choice); `gpu.md` (#885).

## Companion

A `Handbook/VITEPRESS-DOC.md` "Presenting code" section (the feature table, the static-fences-only constraint, a before/after example, the "no code-group for a correspondence pair" rule) goes as a separate Handbook PR.

## Verification

Full `julia --project=. docs/make.jl`: exit 0, **0** `Cannot resolve @ref`. `migration.html` has 10 `line diff` spans (5+5), 1 `has-error`, 1 `has-warning`; `flows/overview.html` has no `<ol>`. Only build errors are the 4 unchanged Phase-D `@extref` items.

Add the `run documentation` label to build the site in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)