### PR TITLE
docs: render CairoMakie figures as SVG, like Plots

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -40,15 +40,18 @@ using JLD2
 
 # plotting
 using Plots
+import CairoMakie   # `import`, not `using`: keeps Makie's `plot`/`plot!` out of Main,
+# which would collide with Plots' in the `@docs` block on results/plot.md
 
 # DocumenterVitepress picks the highest-priority MIME type a plot object responds to
 # (image/png: 4.0 over image/svg+xml: 3.0) — the opposite of Documenter.HTML, which
-# prefers SVG. Plots.jl (unlike CairoMakie) responds to both, so PNG wins unless this
-# is disabled. Global, not per-page: Base.showable is a method on the Plots.Plot type,
-# so setting it once here — before any @example block runs — covers every page that
-# ever calls `using Plots`, not just the ones that do today. See Handbook/VITEPRESS-DOC.md
-# "Plot image format — SVG vs PNG".
+# prefers SVG. Both Plots.jl and CairoMakie respond to `image/png`, so PNG wins for
+# every figure unless it is disabled. Set once here, before any @example block runs,
+# so it covers every page present or future — not just the ones plotting today. See
+# Handbook/VITEPRESS-DOC.md "Plot image format — SVG vs PNG".
 Base.showable(::MIME"image/png", ::Plots.Plot) = false
+CairoMakie.activate!(; type="svg")
+Base.showable(::MIME"image/png", ::CairoMakie.Makie.Figure) = false
 
 # DocumenterVitepress (0.3.5) hard-codes `collapsed: false` on every sidebar group
 # (`vitepress_config.jl`'s `pagelist2str` for a nested `name => children` entry), so the


### PR DESCRIPTION
## What

Phase K (#921) added the first Makie page — `examples/logo.md` — but its three figures render as raster **PNG**. DocumenterVitepress ranks `image/png` (4.0) above `image/svg+xml` (3.0), and CairoMakie — *contrary* to the note in `Handbook/VITEPRESS-DOC.md` ("CairoMakie … No action needed") — responds to both MIME types, so PNG wins.

Fixed the same way as Plots (#903): disable PNG capture globally in `make.jl`.

```julia
using Plots
import CairoMakie   # import, not using — see below
Base.showable(::MIME"image/png", ::Plots.Plot) = false
CairoMakie.activate!(; type="svg")
Base.showable(::MIME"image/png", ::CairoMakie.Makie.Figure) = false
```

**Why `import`, not `using`:** `using CairoMakie` pulls Makie's `plot` / `plot!` into `Main`, where they collide with Plots' — the `@docs` block on `results/plot.md` then fails with `undefined binding 'plot!'` and terminates the build. `import` keeps the extension-loading (so `Makie.plot(sol)` still works on the logo page) without the namespace pollution.

## Verification

Full `julia --project=. docs/make.jl`: exit 0, **0** `Cannot resolve @ref`, no `docs_block` error. **All 50 built figures are now `.svg`** (the logo page's three included). Only remaining build errors are the 4 unchanged Phase-D `@extref` items.

## Companion

`Handbook/VITEPRESS-DOC.md`'s "Plot image format" bullet still says CairoMakie needs no action — corrected in [Handbook#18](https://github.com/control-toolbox/Handbook/pull/18).

Add the `run documentation` label to build the site in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)