### PR TITLE
docs: convert two ordered lists to bullets (phase M)

### DIFF
--- a/src/helpers/component_completion.jl
+++ b/src/helpers/component_completion.jl
@@ -4,10 +4,10 @@ $(TYPEDSIGNATURES)
 Complete missing resolution components using the registry.
 
 This function orchestrates the component completion workflow:
-1. Extract symbols from provided components using `_build_partial_description`
-2. Complete the method description using `_complete_description`
-3. Resolve method with parameter information using `CTBase.Orchestration.resolve_method`
-4. Build or use strategies for each family using `_build_or_use_strategy`
+- Extract symbols from provided components using `_build_partial_description`
+- Complete the method description using `_complete_description`
+- Resolve method with parameter information using `CTBase.Orchestration.resolve_method`
+- Build or use strategies for each family using `_build_or_use_strategy`
 
 # Arguments
 - `discretizer::Union{CTSolvers.DOCP.AbstractDiscretizer, Nothing}`: Discretization strategy or `nothing`

--- a/src/solve/dispatch.jl
+++ b/src/solve/dispatch.jl
@@ -4,9 +4,9 @@ $(TYPEDSIGNATURES)
 Main entry point for optimal control problem resolution.
 
 This function orchestrates the complete solve workflow by:
-1. Detecting the resolution mode (explicit vs descriptive) from arguments
-2. Extracting or creating the strategy registry for component completion
-3. Dispatching to the appropriate Layer 2 solver based on the detected mode
+- Detecting the resolution mode (explicit vs descriptive) from arguments
+- Extracting or creating the strategy registry for component completion
+- Dispatching to the appropriate Layer 2 solver based on the detected mode
 
 # Arguments
 - `ocp::CTModels.AbstractModel`: The optimal control problem to solve


### PR DESCRIPTION
## What

`DocumenterVitepress` mis-renders ordered lists sourced from docstrings — valid `1. 2. 3.` comes out as `<ol start="3">`, the first item absorbed as unstyled prose glued onto the preceding paragraph. [LuxDL/DocumenterVitepress.jl#150](https://github.com/LuxDL/DocumenterVitepress.jl/issues/150), open, no fix.

Confirmed on the built site before this change: `docs/build/1/api/internals.html` and `docs/build/1/api/solving.html` both showed the mis-render.

Fixes the two lists that live in this package's own `src/` — no release or compat bump needed:

- `src/solve/dispatch.jl` — the 3-step resolution-mode dispatch workflow
- `src/helpers/component_completion.jl` — the 4-step component-completion workflow

Marker-only change (`1. ` → `- `), no prose edits.

## Context

This is the OptimalControl leg of a five-repo sweep. Phase E5 already fixed the two occurrences living directly in `docs/src/` (guided tour, `flows/overview.md`); this closes the remainder. The same bug recurs in CTBase, CTSolvers, CTModels.jl and CTFlows.jl — both in their docstrings (transcluded here via `api/*.md`) and, once checked, in three of those repos' own hand-written `docs/src/` guide pages too. Companion PRs open in parallel on all four.

Full plan and the complete 32-item inventory: `.reports/campaign/M-ordered-list-sweep.md`.

**Note**: `api/options.md` and `api/qualified.md` will keep showing this bug on this site until CTBase and CTSolvers release the fix and this package's `[compat]` is raised to reach it (both are registry-resolved dependencies) — tracked as Stage 3 of the same plan, not part of this PR.

## Verified

- Build exit 0.
- `docs/build/1/api/internals.html` and `docs/build/1/api/solving.html`: 0 `<ol start=` occurrences (was 1 each).
- Unresolved `@ref`/errors unchanged from baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)