### PR TITLE
ci: opt this repo's docs build into the GPU upgrade pass (#885 part 2)

### DIFF
--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -8,7 +8,18 @@ on:
       - 'v[0-9]+\.[0-9]+\.[0-9]+'
   pull_request:
     types: [labeled, synchronize, reopened]
-  
+
+# A GPU-attempt job now runs behind every push/tag build (see `gpu_runner` below) and
+# can take up to `gpu_timeout_minutes`. Without this, two pushes to `main` in quick
+# succession could leave an older run's GPU pass finishing — and redeploying — after a
+# newer run's CPU build has already published, showing older content over newer.
+# `cancel-in-progress` cancels the whole older run, its queued/running GPU job
+# included. Tags carry distinct refs (the tag name, not `main`), so a release build is
+# never cancelled by an unrelated push to `main`, and vice versa.
+concurrency:
+  group: documentation-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   call:
     # A 'labeled' event fires once per label added, and re-evaluates against the PR's
@@ -23,5 +34,18 @@ jobs:
     uses: control-toolbox/CTActions/.github/workflows/documentation.yml@main
     with:
       use_ct_registry: true
+      # GPU-backed docs build (#885 part 2): publish then upgrade. The GitHub-hosted
+      # `build` job (unaffected by this) always deploys first; `build-gpu` runs only
+      # once `build` has already published and can only ever improve the already-live
+      # site — see CTActions#71 and .reports/campaign/P-gpu-docs-executable.md for the
+      # full design and the feasibility probe this is based on (Phase D, 2026-09-02:
+      # real GPU on occidata, a `:gpu` solve in 205s, full docs build 2265s, push via
+      # GITHUB_TOKEN/HTTPS confirmed). `build-gpu`'s own `if` already restricts it to
+      # push/tag — inert on PR-preview builds regardless of what's passed here.
+      gpu_runner: '["occidata"]'
+      # Measured cold build on occidata: 2265s (~38 min). Budget with real margin —
+      # this is the number to get right at the top of a Monday, right after the
+      # occidata-runner-maintenance.yml cache purge, not the warm-cache case.
+      gpu_timeout_minutes: 90
     secrets:
       SSH_KEY: ${{ secrets.SSH_KEY }}


### PR DESCRIPTION
Phase F — the last piece of #885. Everything it depends on is merged: [CTActions#71](https://github.com/control-toolbox/CTActions/pull/71) (the reusable `build-gpu` job), [#941](https://github.com/control-toolbox/OptimalControl.jl/pull/941) + [#945](https://github.com/control-toolbox/OptimalControl.jl/pull/945) (`gpu.md` executable, `CTBase` 0.30.4-beta).

Full design and the feasibility probe behind it: [`.reports/campaign/P-gpu-docs-executable.md`](https://github.com/control-toolbox/OptimalControl.jl/blob/main/.reports/campaign/P-gpu-docs-executable.md).

## What this wires

```yaml
with:
  use_ct_registry: true
  gpu_runner: '["occidata"]'
  gpu_timeout_minutes: 90
```

- **`gpu_runner`** opts this repo into the reusable's `build-gpu` job. The existing GitHub-hosted `build` job is untouched and still deploys first, every push and tag — `build-gpu` runs only once `build` has already published (`needs: build`) and, with `continue-on-error: true`, can never fail the workflow. On success it redeploys the same site with real GPU output; on failure, or if `occidata` is queued past its budget, the site `build` already published is simply left in place. **Docs publishing is never on the critical path of a self-hosted box.** `build-gpu`'s own `if` restricts it to `push`/`tag`, so PR-preview builds are unaffected regardless of what's passed here.
- **`gpu_timeout_minutes: 90`** — real margin over the 2265s (~38 min) measured on `occidata` during the Phase D probe (2026-09-02), not the reusable's blanket 120 default. Budgets for the slower case right after `occidata-runner-maintenance.yml`'s Monday 02:30 UTC cache purge, not the same-day warm case that was actually measured.

## New: a `concurrency` group

```yaml
concurrency:
  group: documentation-${{ github.ref }}
  cancel-in-progress: true
```

Load-bearing now that a GPU pass can run behind a push for up to 90 minutes: without it, two pushes to `main` in quick succession could leave an older run's GPU pass finishing — and redeploying — *after* a newer run's CPU build has already published, showing older content over newer. `cancel-in-progress` cancels the whole older run, its queued or running GPU job included. Tags carry distinct refs (the tag name, not `main`), so a release build is never cancelled by an unrelated push to `main`, and vice versa.

## What this PR's own CI will and won't show

`build-gpu` only fires on `push`/`tag`, by design (see above) — so this PR's own preview build stays exactly as fast as every other docs PR today, and does not exercise the new job. The real test is the first push to `main` after merge, where `build` deploys as always and `build-gpu` should show up as a second job in the run graph, landing on `occidata` behind it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
