### PR TITLE
ci: widen the GPU docs pass's timeout to 180 min

### DIFF
--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -43,9 +43,11 @@ jobs:
       # GITHUB_TOKEN/HTTPS confirmed). `build-gpu`'s own `if` already restricts it to
       # push/tag — inert on PR-preview builds regardless of what's passed here.
       gpu_runner: '["occidata"]'
-      # Measured cold build on occidata: 2265s (~38 min). Budget with real margin —
-      # this is the number to get right at the top of a Monday, right after the
-      # occidata-runner-maintenance.yml cache purge, not the warm-cache case.
-      gpu_timeout_minutes: 90
+      # Measured cold build on occidata: 2265s (~38 min). occidata is a single shared
+      # box — other repos' CI (e.g. CTDirect's test-gpu-occidata job) can queue ahead
+      # of this one, and Monday mornings add the occidata-runner-maintenance.yml cache
+      # purge on top. continue-on-error means a longer timeout costs nothing (build
+      # already published beforehand) — budget generously.
+      gpu_timeout_minutes: 180
     secrets:
       SSH_KEY: ${{ secrets.SSH_KEY }}


### PR DESCRIPTION
Follow-up to #946. `occidata` is a single shared box: other repos' CI (e.g. CTDirect's `test-gpu-occidata` job, observed queuing ahead of this one in run 33647921307) and the Monday cache purge in `occidata-runner-maintenance.yml` both eat into a 90 min budget. Since `build-gpu` has `continue-on-error: true` and only runs after the CPU `build` has already published, a longer timeout carries no publication-reliability cost — only a later opportunistic GPU upgrade on a busy day.

90 → 180 min.

🤖 Generated with [Claude Code](https://claude.com/claude-code)