### PR TITLE
docs: drop the inverted draft setup (#948)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,8 @@ Dependency realignment onto the released control-toolbox ecosystem, the v2.0 →
 
 - **`_strategy_parameter` docstring no longer emits an unresolvable `@extref`** ([#943](https://github.com/control-toolbox/OptimalControl.jl/issues/943)). It cross-referenced `CTBase.Strategies.parameter` by method signature (`parameter(T, default)` / `parameter(T)`), but CTBase's auto-generated reference indexes the function under a single anchor, so neither link resolved. Collapsed to the one anchor; `docs/make.jl`'s `warnonly` comment refreshed. The remaining `@extref` warnings (`Plots.plot(::CTModels.Solutions.Solution)`) are fixed upstream in [CTModels 0.19.4-beta](https://github.com/control-toolbox/CTModels.jl/issues/427).
 
+- **`docs/make.jl` runs `draft = false` by default** ([#948](https://github.com/control-toolbox/OptimalControl.jl/issues/948)). The build used to ship `draft = true` globally with a `@meta Draft = false` block repeated in 43 pages to opt each one back into execution — a double negative that also blocked a fast `draft = true` pass for link/nav checks. Now the default executes every page; flip the one flag in `make.jl` for a fast local build, or set `Draft = true` in a single page's `@meta` to exclude it. The guided-tour `Draft = false` Literate injection is removed.
+
 ### 📦 Dependencies
 
 - **Realigned on the released ecosystem** — every sibling resolves from the General registry with no `Pkg.develop`: CTBase `0.28`→`0.29`, CTModels `0.15`→`0.18`, CTSolvers `0.4`→`0.5`, CTFlows `0.16`→`0.17`, CTParser `0.8`→`0.9`, CTLie `0.1`→`0.2`; CTDirect stays pinned to `1` (the major alone, per the pinning-granularity rule)

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -127,14 +127,17 @@ cp(
 # ═══════════════════════════════════════════════════════════════════════════════
 # Configuration
 # ═══════════════════════════════════════════════════════════════════════════════
-# if draft is true, then the julia code from .md is not executed
-# to disable the draft mode in a specific markdown file, use the following:
+# `draft = false` is the committed default: every page executes its `@example` /
+# `@repl` blocks, which is what a published build must do. Flip this to `true`
+# locally for a fast build that skips all execution (checking navigation, links,
+# `@extref`/`@ref` resolution, rendering). To keep one specific page drafted while
+# the rest execute, add to its `@meta` block:
 #=
 ```@meta
-Draft = false
+Draft = true
 ```
 =#
-draft = true  # Draft mode: skip @example execution globally; guided tour overrides below
+draft = false
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # Load extensions
@@ -235,17 +238,10 @@ mkpath(JL_OUTPUT)
 
 for file in ["guided-tour.jl"]
     INPUT = joinpath(LITERATE_DIR, file)
-    # The guided tour executes like every other real page: inject `Draft = false`
-    # into the generated page's `@meta` block so its code runs under the global
-    # `draft = true` (Phase E5). The PR-2-era comment here claimed executing it
-    # "surfaced several unrelated runtime bugs" — those were upstream and have
-    # since been fixed; the tour now builds clean.
-    add_draft_false =
-        content -> replace(
-            content,
-            "EditURL = \"../../src-literate/$file\"\n" => "EditURL = \"../../src-literate/$file\"\nDraft = false\n",
-        )
-    Literate.markdown(INPUT, MD_OUTPUT; name="guided-tour", postprocess=add_draft_false)
+    # The guided tour executes like every other real page under the global
+    # `draft = false`. (It once carried an injected `Draft = false` override to run
+    # under a `draft = true` default; that default is gone.)
+    Literate.markdown(INPUT, MD_OUTPUT; name="guided-tour")
     Literate.notebook(INPUT, NB_OUTPUT; name="guided-tour", execute=false)
     Literate.script(INPUT, JL_OUTPUT; name="guided-tour")
 end
@@ -273,14 +269,10 @@ with_api_reference(src_dir, ext_dir) do api_pages
         # in docs/Manifest.toml, :external_cross_references can be dropped from this list so a
         # future unresolved @extref fails the build. See .reports/campaign/D-api-reference.md.
         #
-        # :example_block is deliberately *not* here: the one remaining un-expanded @example
-        # (CTParser's @def docstring, control-toolbox/CTParser.jl#341, transcluded onto
-        # api/modelling.md) is a side effect of `draft` mode skipping execution and is never
-        # added to `doc.internal.errors` — confirmed by testing that a genuinely broken
-        # @example block on a Draft=false page (this file rewritten to error) still fails the
-        # build with :example_block even with this exact warnonly list, while the CTParser one
-        # stays silent either way. Excluding :example_block would have hidden real breakage for
-        # no benefit.
+        # :example_block is deliberately *not* here: with `draft = false` every page
+        # executes, and a genuinely broken `@example` / `@repl` block must fail the build.
+        # Verified: an error introduced into any executing block still fails with
+        # :example_block under this exact warnonly list.
         warnonly=[:cross_references, :external_cross_references],
         sitename="OptimalControl.jl",
         format=DocumenterVitepress.MarkdownVitepress(;

--- a/docs/src/examples/control-and-variable.md
+++ b/docs/src/examples/control-and-variable.md
@@ -1,9 +1,5 @@
 # [Control and variable together](@id examples-control-and-variable)
 
-```@meta
-Draft = false
-```
-
 The same two systems as [Parameter estimation without a control](@ref examples-control-free),
 now with a control input and a quadratic control cost — estimating a parameter *and* a control
 at the same time. Read that page first; this one skips the narration that doesn't change.

--- a/docs/src/examples/control-free.md
+++ b/docs/src/examples/control-free.md
@@ -1,9 +1,5 @@
 # [Parameter estimation without a control](@id examples-control-free)
 
-```@meta
-Draft = false
-```
-
 Two problems with no control anywhere — only a `variable` to fit to data. See
 [No control](@ref modelling-without-control) for the modelling side of this;
 this page is the full worked story, direct and indirect, for both.

--- a/docs/src/examples/double-integrator-energy.md
+++ b/docs/src/examples/double-integrator-energy.md
@@ -1,9 +1,5 @@
 # [Energy minimisation](@id examples-double-integrator-energy)
 
-```@meta
-Draft = false
-```
-
 The double integrator — a unit mass sliding frictionlessly on a rail, acceleration as the
 control — transferred between two rest states at minimal energy. The simplest problem on this
 site, and the same one used to introduce the package on the home page.

--- a/docs/src/examples/double-integrator-time.md
+++ b/docs/src/examples/double-integrator-time.md
@@ -1,9 +1,5 @@
 # [Time minimisation (bang–bang)](@id examples-double-integrator-time)
 
-```@meta
-Draft = false
-```
-
 Same wagon as [Energy minimisation](@ref examples-double-integrator-energy), but transferred
 **as fast as possible** instead of at minimal energy — a bounded control gives a bang–bang
 optimal law with a single switch.

--- a/docs/src/examples/gallery.md
+++ b/docs/src/examples/gallery.md
@@ -1,9 +1,5 @@
 # [Example gallery](@id examples-gallery)
 
-```@meta
-Draft = false
-```
-
 A guide answers *"how do I do X"*; an example answers *"what does a real problem look like"*.
 Each page here is a complete, self-contained problem worked end to end — a story with a
 result, not a feature demonstration.

--- a/docs/src/examples/logo.md
+++ b/docs/src/examples/logo.md
@@ -1,9 +1,5 @@
 # [The logo](@id examples-logo)
 
-```@meta
-Draft = false
-```
-
 The OptimalControl.jl logo is not a drawing. It is the solution of an optimal control
 problem — an **energy-minimal low-thrust orbit transfer** — solved once and repeated by
 symmetry.

--- a/docs/src/examples/singular-control.md
+++ b/docs/src/examples/singular-control.md
@@ -1,9 +1,5 @@
 # [Singular control](@id examples-singular-control)
 
-```@meta
-Draft = false
-```
-
 A vehicle in the plane with drift, time-optimal, whose extremal control is neither $+1$ nor
 $-1$ on part of the trajectory — a **singular arc**. This is the problem the whole
 [Geometry](@ref geometry-overview) section exists to support: computing that arc's control

--- a/docs/src/examples/state-constraint.md
+++ b/docs/src/examples/state-constraint.md
@@ -1,9 +1,5 @@
 # [State constraint](@id examples-state-constraint)
 
-```@meta
-Draft = false
-```
-
 The double integrator again, this time with a state constraint active on part of the
 trajectory — a boundary arc, a costate jump, and (for the second problem below) a genuine
 multi-arc structure.

--- a/docs/src/examples/turnpike.md
+++ b/docs/src/examples/turnpike.md
@@ -1,9 +1,5 @@
 # [Turnpike (bang–singular–bang)](@id examples-turnpike)
 
-```@meta
-Draft = false
-```
-
 A scalar system, $\dot x = u$ with $u \in [-1,1]$, driven between two states over a fixed
 horizon while minimising $\int x^2$. Because the cost is linear in $u$, the optimal control is
 bang — $u = \pm 1$ — except on an interval where the switching function vanishes: a **singular

--- a/docs/src/flows/accessors.md
+++ b/docs/src/flows/accessors.md
@@ -1,9 +1,5 @@
 # [Accessors](@id flows-accessors)
 
-```@meta
-Draft = false
-```
-
 Building a flow doesn't throw away what it was built from — a flow remembers its Hamiltonian,
 its vector field, the control law you passed in, and the underlying integrator. This page is
 the map of what you can pull back out, and from which kind of flow.

--- a/docs/src/flows/constrained-arcs.md
+++ b/docs/src/flows/constrained-arcs.md
@@ -1,9 +1,5 @@
 # [Constrained arcs](@id flows-constrained-arcs)
 
-```@meta
-Draft = false
-```
-
 A flow along a boundary arc — where a state constraint is active — needs the constraint and
 its multiplier, not just the control law.
 

--- a/docs/src/flows/from-hamiltonians.md
+++ b/docs/src/flows/from-hamiltonians.md
@@ -1,9 +1,5 @@
 # [From Hamiltonians](@id flows-from-hamiltonians)
 
-```@meta
-Draft = false
-```
-
 Every constructor below builds a flow **without** an OCP — the building blocks
 [From an OCP](@ref flows-from-ocp) is itself assembled from. One section per constructor.
 

--- a/docs/src/flows/from-ocp.md
+++ b/docs/src/flows/from-ocp.md
@@ -1,9 +1,5 @@
 # [From an OCP](@id flows-from-ocp)
 
-```@meta
-Draft = false
-```
-
 The main path: you've worked out the PMP's maximising control $u^*(t,x,p,v)$ by hand, and want
 the Hamiltonian flow it defines.
 

--- a/docs/src/flows/multi-phase.md
+++ b/docs/src/flows/multi-phase.md
@@ -1,9 +1,5 @@
 # [Multi-phase flows](@id flows-multi-phase)
 
-```@meta
-Draft = false
-```
-
 Bang-bang switchings, jumps at a boundary arc's entry/exit, phase changes of any kind: a
 sequence of flows, each active on its own sub-interval, concatenated into one callable object —
 itself a flow.

--- a/docs/src/flows/overview.md
+++ b/docs/src/flows/overview.md
@@ -1,9 +1,5 @@
 # [Overview](@id flows-overview)
 
-```@meta
-Draft = false
-```
-
 `Flow` is one constructor that does three distinct jobs: **indirect optimal control** (build
 the Hamiltonian flow of the Pontryagin Maximum Principle, write a shooting function, solve it),
 **simulation** (integrate a controlled system under an open-loop or feedback control), and

--- a/docs/src/flows/shooting.md
+++ b/docs/src/flows/shooting.md
@@ -1,9 +1,5 @@
 # [Shooting](@id flows-shooting)
 
-```@meta
-Draft = false
-```
-
 The payoff of everything else in this section: turn a flow into a root-finding problem for the
 unknown initial costate (and switching times, and free final time), and solve it.
 

--- a/docs/src/flows/simulation.md
+++ b/docs/src/flows/simulation.md
@@ -1,9 +1,5 @@
 # [Simulation](@id flows-simulation)
 
-```@meta
-Draft = false
-```
-
 Sometimes you don't want an optimum — you have a controlled system and a specific control
 (open-loop or feedback), and you want the trajectory it produces.
 

--- a/docs/src/geometry/ad-backend.md
+++ b/docs/src/geometry/ad-backend.md
@@ -1,9 +1,5 @@
 # [AD backend](@id geometry-ad-backend)
 
-```@meta
-Draft = false
-```
-
 ```@example main
 using OptimalControl
 ```

--- a/docs/src/geometry/ad.md
+++ b/docs/src/geometry/ad.md
@@ -1,9 +1,5 @@
 # [Lie derivative and Lie bracket](@id geometry-ad)
 
-```@meta
-Draft = false
-```
-
 `ad(X, foo)` is one function with two meanings, chosen by what `foo` returns.
 
 ```@example main

--- a/docs/src/geometry/lie-macro.md
+++ b/docs/src/geometry/lie-macro.md
@@ -1,9 +1,5 @@
 # [The `@Lie` macro](@id geometry-lie-macro)
 
-```@meta
-Draft = false
-```
-
 `@Lie` lets you write brackets the way you'd write them on paper: square brackets for a Lie
 bracket, curly braces for a Poisson bracket.
 

--- a/docs/src/geometry/lift.md
+++ b/docs/src/geometry/lift.md
@@ -1,9 +1,5 @@
 # [Lift](@id geometry-lift)
 
-```@meta
-Draft = false
-```
-
 Given a vector field $X : \mathbb{R}^n \to \mathbb{R}^n$, its **lift** is the Hamiltonian
 
 ```math

--- a/docs/src/geometry/overview.md
+++ b/docs/src/geometry/overview.md
@@ -1,9 +1,5 @@
 # [Overview](@id geometry-overview)
 
-```@meta
-Draft = false
-```
-
 Some flows can't be built directly from an optimal control problem — the control law itself
 has to be *derived* first, for example a singular control on an arc where the usual
 maximization condition degenerates. Deriving it needs differential-geometry tools: Lie

--- a/docs/src/geometry/poisson.md
+++ b/docs/src/geometry/poisson.md
@@ -1,9 +1,5 @@
 # [Poisson bracket](@id geometry-poisson)
 
-```@meta
-Draft = false
-```
-
 For two Hamiltonians $H, G$,
 
 ```math

--- a/docs/src/getting-started/first-problem.md
+++ b/docs/src/getting-started/first-problem.md
@@ -1,9 +1,5 @@
 # [Your first problem](@id getting-started-first-problem)
 
-```@meta
-Draft = false
-```
-
 The shortest complete story: define a problem, solve it, look at the result. Fifteen lines,
 no options, no theory.
 

--- a/docs/src/getting-started/installation.md
+++ b/docs/src/getting-started/installation.md
@@ -1,9 +1,5 @@
 # [Installation](@id getting-started-installation)
 
-```@meta
-Draft = false
-```
-
 ## Install
 
 Open Julia's [interactive session (REPL)](https://docs.julialang.org/en/v1/manual/getting-started)

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,9 +1,5 @@
 # OptimalControl.jl
 
-```@meta
-Draft = false
-```
-
 The OptimalControl.jl package is the root package of the [control-toolbox ecosystem](https://github.com/control-toolbox). The control-toolbox ecosystem gathers Julia packages for mathematical control and applications. It aims to provide tools to model and solve optimal control problems with ordinary differential equations by direct and indirect methods, both on CPU and GPU.
 
 ## Motivation

--- a/docs/src/migration.md
+++ b/docs/src/migration.md
@@ -1,9 +1,5 @@
 # [Migrating to v2.1](@id migration)
 
-```@meta
-Draft = false
-```
-
 !!! note "This page does not execute"
 
     Unlike every other page on this site, the code blocks here deliberately show **spellings

--- a/docs/src/modelling/abstract-syntax.md
+++ b/docs/src/modelling/abstract-syntax.md
@@ -1,9 +1,5 @@
 # [Abstract syntax (`@def`)](@id modelling-abstract-syntax)
 
-```@meta
-Draft = false
-```
-
 The full grammar of OptimalControl.jl's small *Domain Specific Language* is given below. The idea is to use a syntax that is
 
 - pure Julia (and, as such, effortlessly analysed by the standard Julia parser),

--- a/docs/src/modelling/formulation.md
+++ b/docs/src/modelling/formulation.md
@@ -1,9 +1,5 @@
 # [Formulation](@id modelling-formulation)
 
-```@meta
-Draft = false
-```
-
 An optimal control problem (OCP) with fixed initial and final times can be described as minimising the cost functional (in Bolza form)
 
 ```math

--- a/docs/src/modelling/functional-api.md
+++ b/docs/src/modelling/functional-api.md
@@ -1,9 +1,5 @@
 # [Functional API](@id modelling-functional-api)
 
-```@meta
-Draft = false
-```
-
 The [`@def`](@ref) macro provides a concise DSL to define optimal control problems. An alternative is the **functional API**, which builds the same problem step by step using plain Julia functions.
 
 The functional API uses `OptimalControl.PreModel` as a mutable builder, populated by setter calls, then frozen into an immutable `OptimalControl.Model` by [`build`](@ref). Both `PreModel` and `Model` are imported, not exported — write `OptimalControl.PreModel()`.

--- a/docs/src/modelling/inspect.md
+++ b/docs/src/modelling/inspect.md
@@ -1,9 +1,5 @@
 # [Inspect a problem](@id modelling-inspect)
 
-```@meta
-Draft = false
-```
-
 Once a problem is built — via [`@def`](@ref) or the [functional API](@ref modelling-functional-api) — every part of it can be read back: dimensions, names, dynamics, costs, constraints, traits. This page is about reading a model, not solving it: for that, see [Solve overview](@ref solve-overview); for the indirect/PMP route, see [Flows overview](@ref flows-overview).
 
 !!! note "Signatures and `is_*` aliases"

--- a/docs/src/modelling/with-ai.md
+++ b/docs/src/modelling/with-ai.md
@@ -1,9 +1,5 @@
 # [With AI](@id modelling-with-ai)
 
-```@meta
-Draft = false
-```
-
 Using now common models from AI, it is an elementary task to have such an agent learn the syntax of OptimalControl.jl DSL, then use the agent to translate standard math into this DSL. Here is a typical prompt, pointing to the [abstract syntax](@ref modelling-abstract-syntax):
 
 ```text

--- a/docs/src/modelling/without-control.md
+++ b/docs/src/modelling/without-control.md
@@ -1,9 +1,5 @@
 # [No control](@id modelling-without-control)
 
-```@meta
-Draft = false
-```
-
 ## What this is for
 
 Control-free problems are optimal control problems without a control variable — used for **optimising constant parameters in dynamical systems**, such as:

--- a/docs/src/results/plot-makie.md
+++ b/docs/src/results/plot-makie.md
@@ -1,9 +1,5 @@
 # [Plot with Makie](@id results-plot-makie)
 
-```@meta
-Draft = false
-```
-
 This site draws with [Plots.jl](@ref results-plot) by default. [Makie.jl](https://docs.makie.org)
 is the second backend, at feature parity — same figures, same keywords. The one real
 difference is how you call it, and that difference is worth a page of its own.

--- a/docs/src/results/plot.md
+++ b/docs/src/results/plot.md
@@ -1,9 +1,5 @@
 # [Plot](@id results-plot)
 
-```@meta
-Draft = false
-```
-
 `plot`/`plot!` extend [Plots.jl](https://docs.juliaplots.org) to draw a [`Solution`](@ref results-solution)
 directly — the same call works on a `Flow`-produced trajectory too (last section below). The
 full signatures are collected under [Reference](@ref results-plot-reference) at the end.

--- a/docs/src/results/save-load.md
+++ b/docs/src/results/save-load.md
@@ -1,9 +1,5 @@
 # [Save & load](@id results-save-load)
 
-```@meta
-Draft = false
-```
-
 Persist a solution to disk and read it back — for expensive solves you don't want to redo,
 warm starts across sessions, or sharing a result with someone who doesn't have the code that
 produced it.

--- a/docs/src/results/solution.md
+++ b/docs/src/results/solution.md
@@ -1,9 +1,5 @@
 # [Solution object](@id results-solution)
 
-```@meta
-Draft = false
-```
-
 Everything you do after something has been computed: read the trajectories, check whether it
 converged, read the sensitivities. This page mirrors [Inspect a problem](@ref modelling-inspect)
 — that page reads a *model* back, this one reads a *solution* back — and the two sections link

--- a/docs/src/solve/choosing-a-method.md
+++ b/docs/src/solve/choosing-a-method.md
@@ -1,9 +1,5 @@
 # [Choosing a method](@id solve-choosing-a-method)
 
-```@meta
-Draft = false
-```
-
 A **method** is a quadruplet `(discretizer, modeler, solver, parameter)`. This page maps out
 what can be combined with what, how a partial description gets completed, and how to inspect
 any one piece before you commit to it.

--- a/docs/src/solve/explicit-mode.md
+++ b/docs/src/solve/explicit-mode.md
@@ -1,9 +1,5 @@
 # [Explicit mode](@id solve-explicit-mode)
 
-```@meta
-Draft = false
-```
-
 Instead of symbolic tokens, pass `solve` typed strategy instances — full control over each
 component's configuration, no completion-order guessing.
 

--- a/docs/src/solve/gpu.md
+++ b/docs/src/solve/gpu.md
@@ -1,9 +1,5 @@
 # [GPU](@id solve-gpu)
 
-```@meta
-Draft = false
-```
-
 GPU support runs through [ExaModels.jl](https://exanauts.github.io/ExaModels.jl/stable) and
 [MadNLPGPU.jl](https://github.com/MadNLP/MadNLP.jl), NVIDIA GPUs only, via
 [CUDA.jl](https://github.com/JuliaGPU/CUDA.jl).

--- a/docs/src/solve/initial-guess.md
+++ b/docs/src/solve/initial-guess.md
@@ -1,9 +1,5 @@
 # [Initial guess](@id solve-initial-guess)
 
-```@meta
-Draft = false
-```
-
 Every way to hand `solve` a starting point: constants, functions, grids, a previous solution,
 or nothing at all.
 

--- a/docs/src/solve/options.md
+++ b/docs/src/solve/options.md
@@ -1,9 +1,5 @@
 # [Options](@id solve-options)
 
-```@meta
-Draft = false
-```
-
 Every keyword argument passed to `solve` ends up on exactly one strategy — the discretizer,
 the modeler, or the solver. This page covers how that routing works, the two escape hatches
 for the cases it doesn't handle automatically, and how to inspect where a value came from.

--- a/docs/src/solve/overview.md
+++ b/docs/src/solve/overview.md
@@ -1,9 +1,5 @@
 # [Overview](@id solve-overview)
 
-```@meta
-Draft = false
-```
-
 `solve` is the entry point for the direct methods: transcribe the problem, hand it to an NLP
 solver, get a [`Solution`](@ref results-solution) back. This page shows the quickest way to call it, how to read
 what it printed, and the two ways to steer it away from its defaults.


### PR DESCRIPTION
Closes #948.

## Before

`docs/make.jl`: `draft = true` global, and **43** content pages each carrying

```
```@meta
Draft = false
```
```

to opt back into `@example` / `@repl` execution — a double negative across 44 files. The
guided tour additionally got `Draft = false` injected by a Literate `postprocess`.

- A new page without the marker is silently **not executed**.
- No fast `draft = true` pass possible (nav / link / `@ref` / `@extref` / render checks)
  without stripping 43 markers first.

## After

- `make.jl`: `draft = false` default — every page executes (what a published build does).
  Flip the one flag locally for a fast build.
- 43 `@meta Draft = false` blocks removed; guided-tour injection removed.
- `make.jl` comments refreshed; stale `:example_block` note trimmed (CTParser#341 closed).
- Opt a single page **out** of execution with `Draft = true` in its `@meta`.

Safe: only `api/ecosystem.md` (no code) and generated `guided-tour.md` lacked a marker;
neither relied on being skipped.

## Verification

Full local build, `julia --project=. docs/make.jl` (`draft = false`):

- exit 0; `Doctest`, `ExpandTemplates`, `ExtCrossReferences`, `CrossReferences`,
  `CheckDocument`, `RenderDocument` all pass
- every `@example` / `@repl` executes — inline SVG figures present in `results/plot.html`,
  `getting-started/guided-tour.html`, …; computed values rendered in
  `getting-started/first-problem.html`
- `@extref` unresolved: **0**; `@ref` unresolved: **0**
- only residual warnings: 2× "Failed to load inventory CTDirect/CTParser" (local
  `objects.inv` absent → network fallback), deploy-env, favicon — all pre-existing

`docs/src/assets/Manifest.toml` deliberately **not** touched here — no dep/compat change;
the CTModels 0.19.4-beta / CTBase 0.30.4-beta Manifest refresh belongs in its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
