### PR TITLE
docs: only try the local sibling inventory outside CI

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -161,42 +161,30 @@ include("api_reference.jl")
 # ═══════════════════════════════════════════════════════════════════════════════
 # InterLinks
 # ═══════════════════════════════════════════════════════════════════════════════
+# CI never has the sibling control-toolbox repos checked out next to this one, so the
+# local sibling `objects.inv` path below can never resolve there — DocumenterInterLinks
+# tries it first, fails, and logs a Warning before falling back to the remote inventory,
+# 7 times on every single CI run (see #950). Only include the local path outside CI, so
+# the CI runner's tuple has just the 2 sources that can actually succeed. Order stays
+# local-first when present: a contributor with siblings cloned and built locally sees
+# their own in-progress docstring/@extref changes, not the last stable release.
+const IN_CI = get(ENV, "CI", "false") == "true"
+
+function sibling_inventory(dir_name::AbstractString, base_url::AbstractString)
+    remote = (base_url, base_url * "objects.inv")
+    IN_CI && return remote
+    local_inv = joinpath(@__DIR__, "..", "..", dir_name, "docs", "build", "1", "objects.inv")
+    return (base_url, local_inv, base_url * "objects.inv")
+end
+
 links = InterLinks(
-    "CTBase" => (
-        "https://control-toolbox.org/CTBase.jl/stable/",
-        joinpath(@__DIR__, "..", "..", "CTBase", "docs", "build", "1", "objects.inv"),
-        "https://control-toolbox.org/CTBase.jl/stable/objects.inv",
-    ),
-    "CTDirect" => (
-        "https://control-toolbox.org/CTDirect.jl/stable/",
-        joinpath(@__DIR__, "..", "..", "CTDirect.jl", "docs", "build", "1", "objects.inv"),
-        "https://control-toolbox.org/CTDirect.jl/stable/objects.inv",
-    ),
-    "CTFlows" => (
-        "https://control-toolbox.org/CTFlows.jl/stable/",
-        joinpath(@__DIR__, "..", "..", "CTFlows.jl", "docs", "build", "1", "objects.inv"),
-        "https://control-toolbox.org/CTFlows.jl/stable/objects.inv",
-    ),
-    "CTLie" => (
-        "https://control-toolbox.org/CTLie.jl/stable/",
-        joinpath(@__DIR__, "..", "..", "CTLie", "docs", "build", "1", "objects.inv"),
-        "https://control-toolbox.org/CTLie.jl/stable/objects.inv",
-    ),
-    "CTModels" => (
-        "https://control-toolbox.org/CTModels.jl/stable/",
-        joinpath(@__DIR__, "..", "..", "CTModels.jl", "docs", "build", "1", "objects.inv"),
-        "https://control-toolbox.org/CTModels.jl/stable/objects.inv",
-    ),
-    "CTParser" => (
-        "https://control-toolbox.org/CTParser.jl/stable/",
-        joinpath(@__DIR__, "..", "..", "CTParser.jl", "docs", "build", "1", "objects.inv"),
-        "https://control-toolbox.org/CTParser.jl/stable/objects.inv",
-    ),
-    "CTSolvers" => (
-        "https://control-toolbox.org/CTSolvers.jl/stable/",
-        joinpath(@__DIR__, "..", "..", "CTSolvers", "docs", "build", "1", "objects.inv"),
-        "https://control-toolbox.org/CTSolvers.jl/stable/objects.inv",
-    ),
+    "CTBase" => sibling_inventory("CTBase", "https://control-toolbox.org/CTBase.jl/stable/"),
+    "CTDirect" => sibling_inventory("CTDirect.jl", "https://control-toolbox.org/CTDirect.jl/stable/"),
+    "CTFlows" => sibling_inventory("CTFlows.jl", "https://control-toolbox.org/CTFlows.jl/stable/"),
+    "CTLie" => sibling_inventory("CTLie", "https://control-toolbox.org/CTLie.jl/stable/"),
+    "CTModels" => sibling_inventory("CTModels.jl", "https://control-toolbox.org/CTModels.jl/stable/"),
+    "CTParser" => sibling_inventory("CTParser.jl", "https://control-toolbox.org/CTParser.jl/stable/"),
+    "CTSolvers" => sibling_inventory("CTSolvers", "https://control-toolbox.org/CTSolvers.jl/stable/"),
     "ADNLPModels" => (
         "https://jso.dev/ADNLPModels.jl/stable/",
         joinpath(@__DIR__, "inventories", "ADNLPModels.toml"),


### PR DESCRIPTION
Closes #950.

`DocumenterInterLinks` tries each `InterLinks` source in order and falls back on failure. The local sibling `objects.inv` path in [`docs/make.jl`](https://github.com/control-toolbox/OptimalControl.jl/blob/main/docs/make.jl) (kept first so a contributor with sibling repos cloned and built locally sees their own in-progress docstring/`@extref` changes, not the last stable release) can never resolve on CI — only this repo is checked out there — so every CI run logged 7 `Failed to load inventory` warnings, one per control-toolbox sibling (CTBase, CTDirect, CTFlows, CTLie, CTModels, CTParser, CTSolvers), before falling back to the remote inventory that always succeeds.

`sibling_inventory(dir_name, base_url)` now drops the local path entirely when `ENV["CI"] == "true"`, so CI's tuple only ever contains sources that can actually succeed (base URL + remote inventory). Local-dev ordering and behavior are unchanged — local-first when the path exists, same fallback to the remote URL otherwise.

Verified locally, both branches of the conditional:
- `CI=true julia --project=docs/ -e 'include("docs/make.jl")'` → full build completes, **0** `Failed to load inventory` lines, no errors.
- dev-mode tuple shape unchanged (still 3 entries, local-first) when `CI` is unset.

No behavior change for the 4 non-sibling entries (ADNLPModels, NLPModelsIpopt, ExaModels, MadNLP, Tutorials) — those already use committed `docs/inventories/*.toml` files, not a sibling build path, so they were never affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)